### PR TITLE
.editorconfig enforces new line settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,7 @@ root = true
 [*.cs]
 indent_style = tab
 indent_size = 4
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true


### PR DESCRIPTION
Visual Studio 2017 has its own supported settings for different languages. These four settings will enforce new lines before opening braces and `else`/`catch`/`finally` statements. I tested these in VS2017 15.2 and they work as intended. There's a smaller list of supported settings on the [Roslyn GitHub](https://github.com/dotnet/roslyn/blob/master/.editorconfig) and a longer one without descriptions on the [EditorConfigLanguage GitHub](https://github.com/madskristensen/EditorConfigLanguage/issues/10#issuecomment-310120306).
