### PR TITLE
Object overload for Main.NewText

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3794,7 +3794,7 @@
  			if (Main.ignoreErrors)
  			{
  				try
-@@ -58909,6 +_,11 @@
+@@ -58909,6 +_,16 @@
  					RemoteClient.CheckSection(k, Main.player[k].position, 1);
  				}
  			}
@@ -3803,6 +3803,11 @@
 +		public static void NewText(string newText, Microsoft.Xna.Framework.Color color, bool force = false)
 +		{
 +			NewText(newText, color.R, color.G, color.B, force);
++		}
++
++		public static void NewText(object o, Microsoft.Xna.Framework.Color color = default(Microsoft.Xna.Framework.Color), bool force = false)
++		{
++			NewText(o.ToString(), color.R, color.G, color.B, force);
  		}
  
  		public static void NewText(string newText, byte R = 255, byte G = 255, byte B = 255, bool force = false)


### PR DESCRIPTION
### Description of the Change

Added the object overload for Main.NewText

### Benefits

Removes the need to call object.ToString manually

