### PR TITLE
Resolves #232

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.UI/UIModBrowser.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/UIModBrowser.cs
@@ -464,7 +464,7 @@ namespace Terraria.ModLoader.UI
 					bool exists = false;
 					bool update = false;
 					bool updateIsDowngrade = false;
-					var installed = installedMods.SingleOrDefault(m => m.name == name);
+					var installed = installedMods.FirstOrDefault(m => m.name == name);
 					if (installed != null)
 					{
 						exists = true;


### PR DESCRIPTION
<!-- Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Where applicable, provide Example Mod usage (example code), see the 'Sample usage' section
* If a header/description isn't applicable to your PR, leave it empty or remove it -->

### Description of the Change

This pull request resolves #232 as requested by @JavidPack.  As @Chicken-Bones mentioned, duplicate mods still display in the mods menu and instead an error is thrown on loading and the duplicate mods are disabled (already implemented, not by me).  Pretty quick change, just thought I'd go ahead and push it since there hadn't been any work on this issue in a few days.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate designs

Proposed version was selected based on discussion as seen in #232.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why this should be merged into tModLoader

Simple, quick fix for issue as requested by @Jofairden.

<!-- Explain why this functionality should be in our API as opposed to something standalone (like a mod/framework etc.) -->

### Benefits

Better management of situations where an internal mod name is not distinct.

<!-- What benefits will be realized by the code change? -->

### Applicable Issues

#232 


