### PR TITLE
Bugfix LanguageManager.ProcessCopyCommandsInTexts crash (Resolves #230)

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModTile.cs
@@ -150,7 +150,7 @@ namespace Terraria.ModLoader
 			{
 				key = Name;
 			}
-			return new ModTranslation(string.Format("MapObject.{0}.{1}", mod.Name, key), true);
+			return new ModTranslation($"MapObject.{mod.Name}.{key}", true);
 		}
 
 		/// <summary>
@@ -158,15 +158,13 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public void AddMapEntry(Color color, ModTranslation name)
 		{
-			if (!MapLoader.initialized)
+			if (MapLoader.initialized) return;
+			MapEntry entry = new MapEntry(color, name);
+			if (!MapLoader.tileEntries.Keys.Contains(Type))
 			{
-				MapEntry entry = new MapEntry(color, name);
-				if (!MapLoader.tileEntries.Keys.Contains(Type))
-				{
-					MapLoader.tileEntries[Type] = new List<MapEntry>();
-				}
-				MapLoader.tileEntries[Type].Add(entry);
+				MapLoader.tileEntries[Type] = new List<MapEntry>();
 			}
+			MapLoader.tileEntries[Type].Add(entry);
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria.ModLoader/ModTranslation.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModTranslation.cs
@@ -14,7 +14,7 @@ namespace Terraria.ModLoader
 		{
 			this.Key = key;
 			this.translations = new Dictionary<int, string>();
-			this.translations[fallback] = defaultEmpty ? null : key;
+			this.translations[fallback] = defaultEmpty ? "" : key;
 		}
 
 		public void SetDefault(string value)


### PR DESCRIPTION
<!-- Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Where applicable, provide Example Mod usage (example code), see the 'Sample usage' section
* If a header/description isn't applicable to your PR, leave it empty or remove it -->

### Description of the Change

Resolves a crash in LanguageManager.ProcessCopyCommandsInTexts caused by the specific bit of code mentioned by @JavidPack in #230.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate designs

Chose version proposed in #230.  @Jofairden brought up the possibility of the programmer passing a null value to AddMapEntry, but I don't think this is a concern because either the compiler will not be able to resolve between the overloaded methods of AddMapEntry or the programmer is using an uninitialized variable, which in tModLoader's case aborts the compilation process.  I am very tired though so I am probably missing something.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Applicable Issues

#230 

<!-- Enter any applicable issues here -->

