### PR TITLE
Normalizes translation to one entry per sentence + Adds Chinese translation

### DIFF
--- a/patches/tModLoader/Terraria.Localization.Content.en-US.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.en-US.tModLoader.json
@@ -13,7 +13,7 @@
 		"ModsOpenModsFolder": "Open Mods Folder",
 		"ModsModPacks": "Mod Packs",
 		"ModsDisable": "Disable",
-		"ModsEnable": "Enable", 
+		"ModsEnable": "Enable",
 		"ModsMoreInfo": "More info",
 		"ModsOriginatedFromModBrowser": "This mod originated from the Mod Browser",
 		"ModsTypeToSearch": "Type to search",
@@ -24,7 +24,7 @@
 		"ModsSortNamesReverseAlph": "Sort mod names reverse-alphabetically",
 		"ModsShowAllMods": "Show all mods",
 		"ModsShowEnabledMods": "Show only enabled mods",
-		"ModsShowDisabledMods": "Show only disabled mods",	
+		"ModsShowDisabledMods": "Show only disabled mods",
 
 		// Mod Browser
 		"MBDownload": "Download",
@@ -61,12 +61,12 @@
 
 		//There should be ModName after ':'
 		"MSReadingProperties": "Reading Properties: ",
-		//Should be 'MSCompiling + ModName + MSComplingWindows/Mono'
-		"MSCompiling": "Compiling ",
-		"MSCompilingWindows": " for Windows...",
-		"MSCompilingMono": " for Mono...",
 		//There should be ModName after ':'
-		"MSBuilding": "Building ",
+		"MSCompilingWindows": "Compiling for Windows: ",
+		//There should be ModName after ':'
+		"MSCompilingMono": "Compiling for Mono: ",
+		//There should be ModName after ':'
+		"MSBuilding": "Building: ",
 		"MSFinding": "Finding Mods...",
 		//There should be ModName after ':'
 		"MSIntializing": "Initializing: ",

--- a/patches/tModLoader/Terraria.Localization.Content.en-US.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.en-US.tModLoader.json
@@ -1,4 +1,4 @@
-﻿{
+{
 	"tModLoader": {
 		// Main Menu
 		"MenuModBrowser": "Mod Browser",
@@ -13,7 +13,7 @@
 		"ModsOpenModsFolder": "Open Mods Folder",
 		"ModsModPacks": "Mod Packs",
 		"ModsDisable": "Disable",
-		"ModsEnable": "Enable",
+		"ModsEnable": "Enable", 
 		"ModsMoreInfo": "More info",
 		"ModsOriginatedFromModBrowser": "This mod originated from the Mod Browser",
 		"ModsTypeToSearch": "Type to search",
@@ -24,7 +24,7 @@
 		"ModsSortNamesReverseAlph": "Sort mod names reverse-alphabetically",
 		"ModsShowAllMods": "Show all mods",
 		"ModsShowEnabledMods": "Show only enabled mods",
-		"ModsShowDisabledMods": "Show only disabled mods",
+		"ModsShowDisabledMods": "Show only disabled mods",	
 
 		// Mod Browser
 		"MBDownload": "Download",
@@ -46,6 +46,8 @@
 		"DownloadSignedNo": "Only Download Signed Mods From Servers: Off",
 		"MusicStreamModeConvert": "Music Stream Mode: Convert On Demand",
 		"MusicStreamModeStream": "Music Stream Mode: Stream From Cache",
+		"AlwaysLogExceptionsYes": "Always Log Exceptions: On",
+		"AlwaysLogExceptionsNo": "Always Log Exceptions: Off",
 		"ExperimentalFeaturesYes": "Experimental Features: On",
 		"ExperimentalFeaturesNo": "Experimental Features: Off",
 		"ClearMBCredentials": "Clear Mod Browser Credentials",
@@ -61,12 +63,10 @@
 
 		//There should be ModName after ':'
 		"MSReadingProperties": "Reading Properties: ",
+		"MSCompilingWindows": "Compiling {0} for Windows...",
+		"MSCompilingMono": "Compiling {0} for Mono...",
 		//There should be ModName after ':'
-		"MSCompilingWindows": "Compiling for Windows: ",
-		//There should be ModName after ':'
-		"MSCompilingMono": "Compiling for Mono: ",
-		//There should be ModName after ':'
-		"MSBuilding": "Building: ",
+		"MSBuilding": "Building ",
 		"MSFinding": "Finding Mods...",
 		//There should be ModName after ':'
 		"MSIntializing": "Initializing: ",

--- a/patches/tModLoader/Terraria.Localization.Content.es-ES.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.es-ES.tModLoader.json
@@ -1,7 +1,7 @@
 {
 	"tModLoader": {
 		// Main Menu
-		"MenuModBrowser": "Navegador de Mods", 
+		"MenuModBrowser": "Navegador de Mods",
 		"MenuMods": "Mods",
 		"MenuModSources": "Fuente de Mods",
 
@@ -13,18 +13,18 @@
 		"ModsOpenModsFolder": "Abrir la carpeta de Mods",
 		"ModsModPacks": "Paquete de Mods",
 		"ModsDisable": "Deshabilitar",
-		"ModsEnable": "Habilitar", 
+		"ModsEnable": "Habilitar",
 		"ModsMoreInfo": "Más Información",
 		"ModsOriginatedFromModBrowser": "Este Mod se origino del Navegador de Mods",
 		"ModsTypeToSearch": "Escribe para buscar",
 		"ModsSearchByModName": "Buscar por el nombre del mod",
 		"ModsSearchByAuthor": "Buscar por el nombre del Autor",
-		"ModsSortRecently": "Ordenar mods cambiados recientemente", 
+		"ModsSortRecently": "Ordenar mods cambiados recientemente",
 		"ModsSortNamesAlph": "Ordenar nombres de mods en orden alfabético",
 		"ModsSortNamesReverseAlph": "Ordenar nombres de mods en orden alfabético inverso",
 		"ModsShowAllMods": "Mostrar todos los mods",
 		"ModsShowEnabledMods": "Mostrar solo los mods habilitados",
-		"ModsShowDisabledMods": "Mostrar sólo mods deshabilitados",	
+		"ModsShowDisabledMods": "Mostrar sólo mods deshabilitados",
 
 		// Mod Browser
 		"MBDownload": "Descargar",
@@ -61,10 +61,10 @@
 
 		//There should be ModName after ':'
 		"MSReadingProperties": "Leyendo las propiedades: ",
-		//Should be 'MSCompiling + ModName + MSComplingWindows/Mono'
-		"MSCompiling": "Compilando ",
-		"MSCompilingWindows": " por Windows...",
-		"MSCompilingMono": " por Mono...",
+		//There should be ModName after ':'
+		"MSCompilingWindows": "Compilando por Windows:",
+		//There should be ModName after ':'
+		"MSCompilingMono": "Compilando por Mono:",
 		//There should be ModName after ':'
 		"MSBuilding": "Construyendo ",
 		"MSFinding": "Buscando Mods...",

--- a/patches/tModLoader/Terraria.Localization.Content.fr-FR.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.fr-FR.tModLoader.json
@@ -13,7 +13,7 @@
 		"ModsOpenModsFolder": "Dossier des Modules",
 		"ModsModPacks": "Compile de Modules",
 		"ModsDisable": "Desactiver",
-		"ModsEnable": "Activer", 
+		"ModsEnable": "Activer",
 		"ModsMoreInfo": "Details",
 		"ModsOriginatedFromModBrowser": "Ce Module est Originaire du Navigateur",
 		"ModsTypeToSearch": "Recherche écrite",
@@ -24,7 +24,7 @@
 		"ModsSortNamesReverseAlph": "Trier par Ordre Alphabétique Inversé",
 		"ModsShowAllMods": "Tout Montrer",
 		"ModsShowEnabledMods": "Montrer Uniquement les Modules Actifs",
-		"ModsShowDisabledMods": "Montrer Uniquement les Modules Inactifs",	
+		"ModsShowDisabledMods": "Montrer Uniquement les Modules Inactifs",
 
 		// Mod Browser
 		"MBDownload": "Télécharger",
@@ -61,10 +61,10 @@
 
 		//There should be ModName after ':'
 		"MSReadingProperties": "Analyse des Propriétés: ",
-		//Should be 'MSCompiling + ModName + MSComplingWindows/Mono'
-		"MSCompiling": "Précompilation de ",
-		"MSCompilingWindows": " pour Windows...",
-		"MSCompilingMono": " pour Mono...",
+		//There should be ModName after ':'
+		"MSCompilingWindows": "Précompilation de pour Windows: ",
+		//There should be ModName after ':'
+		"MSCompilingMono": "Précompilation de pour Mono: ",
 		//There should be ModName after ':'
 		"MSBuilding": "Compilation de ",
 		"MSFinding": "Listage des Modules...",

--- a/patches/tModLoader/Terraria.Localization.Content.ru-RU.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.ru-RU.tModLoader.json
@@ -13,7 +13,7 @@
 		"ModsOpenModsFolder": "Открыть папку модов",
 		"ModsModPacks": "Сборки модов",
 		"ModsDisable": "Выключить",
-		"ModsEnable": "Включить", 
+		"ModsEnable": "Включить",
 		"ModsMoreInfo": "Подробнее",
 		"ModsOriginatedFromModBrowser": "Этот мод установлен из Браузера модов",
 		"ModsTypeToSearch": "Поиск",
@@ -59,11 +59,11 @@
 		"MSManagePublished": "Опубликованное",
 		"MSBack": "Назад",
 		//There should be ModName after ':'
-		"MSReadingProperties": "Чтение настроек мода:",
-		//Should be 'MSCompiling + ModName + MSComplingWindows/Mono'
-		"MSCompiling": "Компиляция мода ",
-		"MSCompilingWindows": " для Windows",
-		"MSCompilingMono": " для Mono",
+		"MSReadingProperties": "Чтение настроек мода: ",
+		//There should be ModName after ':'
+		"MSCompilingWindows": "Компиляция мода для Windows: ",
+		//There should be ModName after ':'
+		"MSCompilingMono": "Компиляция мода для Mono: ",
 		//There should be ModName after ':'
 		"MSBuilding": "Сборка мода: ",
 		"MSFinding": "Поиск файлов",

--- a/patches/tModLoader/Terraria.Localization.Content.zh-Hans.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.zh-Hans.tModLoader.json
@@ -61,9 +61,9 @@
 
 		//There should be ModName after ':'
 		"MSReadingProperties": "正在读取相关属性：",
-		//Should be 'MSCompiling + ModName + MSComplingWindows/Mono'
-		"MSCompiling": "正在编译",
+		//There should be ModName after ':'
 		"MSCompilingWindows": "正在编译Windows版：",
+		//There should be ModName after ':'
 		"MSCompilingMono": "正在编译Mono版：",
 		//There should be ModName after ':'
 		"MSBuilding": "正在构建：",

--- a/patches/tModLoader/Terraria.Localization.Content.zh-Hans.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.zh-Hans.tModLoader.json
@@ -1,0 +1,76 @@
+﻿{
+	"tModLoader": {
+		// Main Menu
+		"MenuModBrowser": "模组浏览器",
+		"MenuMods": "模组管理",
+		"MenuModSources": "模组源代码",
+
+		// Mods Menu
+		"ModsModsList": "模组列表",
+		"ModsEnableAll": "启用所有",
+		"ModsDisableAll": "禁用所有",
+		"ModsReloadMods": "重新载入模组",
+		"ModsOpenModsFolder": "打开模组文件夹",
+		"ModsModPacks": "模组包",
+		"ModsDisable": "禁用",
+		"ModsEnable": "启用",
+		"ModsMoreInfo": "更多信息",
+		"ModsOriginatedFromModBrowser": "来自模组浏览器",
+		"ModsTypeToSearch": "搜索",
+		"ModsSearchByModName": "按模组名称来搜索",
+		"ModsSearchByAuthor": "按作者名来搜索",
+		"ModsSortRecently": "按最近更新顺序排序",
+		"ModsSortNamesAlph": "按名称排序（A-Z）",
+		"ModsSortNamesReverseAlph": "按名称排序（Z-A）",
+		"ModsShowAllMods": "显示所有模组",
+		"ModsShowEnabledMods": "只显示已启用的模组",
+		"ModsShowDisabledMods": "只显示已禁用的模组",
+
+		// Mod Browser
+		"MBDownload": "下载",
+		"MBDowngrade": "降级",
+		"MBUpdate": "升级",
+		"MBReloadBrowser": "重新载入浏览器",
+		"MBSortByRecentlyUpdated": "按最近更新顺序排序",
+		"MBSortByPopularity": "按受欢迎程度排序",
+		"MBSortDownloadDesc": "按下载量排序（由高到低）",
+		"MBSortDownloadAsc": "按下载量排序（由低到高）",
+		"MBShowAllMods": "显示所有模组",
+		"MBShowNotInstalledUpdates": "显示未安装或有更新的模组",
+		"MBShowUpdates": "只显示有更新的模组",
+
+		// TML Options
+		"DownloadFromServersYes": "从服务器下载模组：开",
+		"DownloadFromServersNo": "从服务器下载模组：关",
+		"DownloadSignedYes": "从服务器只下载带签名认证的模组：开",
+		"DownloadSignedNo": "从服务器只下载带签名认证的模组：关",
+		"MusicStreamModeConvert": "音乐串流模式：实时转换",
+		"MusicStreamModeStream": "音乐串流模式：缓存优先",
+		"ExperimentalFeaturesYes": "实验性功能：开",
+		"ExperimentalFeaturesNo": "实验性功能：关",
+		"ClearMBCredentials": "清除浏览器身份信息",
+
+		// Mod Sources
+		"MSBuild": "构建项目",
+		"MSBuildReload": "构建并重新载入项目",
+		"MSBuildAll": "构建所有项目",
+		"MSBuildReloadAll": "构建并重新载入所有项目",
+		"MSOpenSources": "打开源代码",
+		"MSManagePublished": "管理已发布项目",
+		"MSPublish": "发布项目",
+
+		//There should be ModName after ':'
+		"MSReadingProperties": "正在读取相关属性：",
+		//Should be 'MSCompiling + ModName + MSComplingWindows/Mono'
+		"MSCompiling": "正在编译",
+		"MSCompilingWindows": "正在编译Windows版：",
+		"MSCompilingMono": "正在编译Mono版：",
+		//There should be ModName after ':'
+		"MSBuilding": "正在构建：",
+		"MSFinding": "正在寻找模组...",
+		//There should be ModName after ':'
+		"MSIntializing": "正在初始化：",
+		//There should be ModName after ':'
+		"MSLoading": "正在载入模组：",
+	}
+}

--- a/patches/tModLoader/Terraria.ModLoader/ModCompile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModCompile.cs
@@ -69,7 +69,7 @@ namespace Terraria.ModLoader
 				.Where(mod => !modList.Exists(m => m.Name == mod.name))
 				.Select(mod => new LoadingMod(mod, BuildProperties.ReadModFile(mod)))
 				.ToList();
-			
+
 			var requiredFromInstall = new HashSet<LoadingMod>();
 			Action<LoadingMod> require = null;
 			require = (mod) => {
@@ -144,7 +144,7 @@ namespace Terraria.ModLoader
 				ErrorLogger.LogBuildError("Failed to load " + Path.Combine(modFolder, "build.txt") + Environment.NewLine + e);
 				return null;
 			}
-			
+
 			var file = Path.Combine(ModPath, modName + ".tmod");
 			var modFile = new TmodFile(file) {
 				name = modName,
@@ -201,14 +201,14 @@ namespace Terraria.ModLoader
 					}
 				}
 				else {
-					status.SetStatus(Language.GetTextValue("tModLoader.MSCompiling") + mod + Language.GetTextValue("tModLoader.MSCompilingWindows"));
+					status.SetStatus(Language.GetTextValue("tModLoader.MSCompilingWindows") + mod);
 					status.SetProgress(0, 2);
 					CompileMod(mod, refMods, true, ref winDLL, ref winPDB);
 				}
 				if (winDLL == null)
 					return false;
 
-				status.SetStatus(Language.GetTextValue("tModLoader.MSCompiling") + mod + Language.GetTextValue("tModLoader.MSCompilingMono"));
+				status.SetStatus(Language.GetTextValue("tModLoader.MSCompilingMono") + mod);
 				status.SetProgress(1, 2);
 				CompileMod(mod, refMods, false, ref monoDLL, ref winPDB);//the pdb reference won't actually be written to
 				if (monoDLL == null)
@@ -235,7 +235,7 @@ namespace Terraria.ModLoader
 
 			foreach (var resource in Directory.GetFiles(mod.path, "*", SearchOption.AllDirectories)) {
 				var relPath = resource.Substring(mod.path.Length + 1);
-				if (mod.properties.ignoreFile(relPath) || 
+				if (mod.properties.ignoreFile(relPath) ||
 						relPath == "build.txt" ||
 						!mod.properties.includeSource && sourceExtensions.Contains(Path.GetExtension(resource)) ||
 						Path.GetFileName(resource) == "Thumbs.db")
@@ -336,7 +336,7 @@ namespace Terraria.ModLoader
 
 			//everything used to compile the tModLoader for the target platform
 			refs.AddRange(GetTerrariaReferences(tempDir, forWindows));
-			
+
 			//libs added by the mod
 			refs.AddRange(mod.properties.dllReferences.Select(refDll => Path.Combine(mod.path, "lib/" + refDll + ".dll")));
 
@@ -475,7 +475,7 @@ namespace Terraria.ModLoader
 			if (!res.Errors.HasErrors && compileOptions.IncludeDebugInformation)
 				asm.GetType("Terraria.ModLoader.RoslynPdbFixer").GetMethod("Fix")
 					.Invoke(null, new object[] { compileOptions.OutputAssembly });
-			
+
 			return res;
 		}
 


### PR DESCRIPTION
### Description of the Change

This PR is about translation of TML itself. It contains two parts.

1. Normalizes the translation structure so that each sentence will only use one text element. This will make it easier to translate because with this change, the location of the non-translated element won't make the sentense akward. They are always at the end of the sentence.
2. Adds the Chinese translation for TML.

### Alternate designs

For the first part, an alternative solution would be to use placeholders in translation. Like "Compiling {mod} for Mono...", or "Compiling {0} for Windows...". But since there is only one instance of combining two translated texts in TML, the proposed approach should be enough.

### Why this should be merged into tModLoader

- It simplifies translation for other languages.
- It adds Chinese translation.

### Benefits

Same as section above.

### Possible drawbacks

Needs to update current translations (which I've done, hopefully correct).