### PR TITLE
Reforge hooks updates

### DIFF
--- a/ExampleMod/Items/Weapons/ExampleSword.cs
+++ b/ExampleMod/Items/Weapons/ExampleSword.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;

--- a/ExampleMod/Items/Weapons/ExampleSword.cs
+++ b/ExampleMod/Items/Weapons/ExampleSword.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;

--- a/ExampleMod/Items/Weapons/ExampleSword.cs
+++ b/ExampleMod/Items/Weapons/ExampleSword.cs
@@ -9,23 +9,23 @@ namespace ExampleMod.Items.Weapons
 	{
 		public override void SetStaticDefaults()
 		{
-			Tooltip.SetDefault("This is a modded sword.");	//The (English) text shown below your weapon's name
+			Tooltip.SetDefault("This is a modded sword.");  //The (English) text shown below your weapon's name
 		}
 
 		public override void SetDefaults()
 		{
-			item.damage = 50;			//The damage of your weapon
-			item.melee = true;			//Is your weapon a melee weapon?
-			item.width = 40;			//Weapon's texture's width
-			item.height = 40;			//Weapon's texture's height
-			item.useTime = 20;			//The time span of using the weapon. Remember in terraria, 60 frames is a second.
-			item.useAnimation = 20;			//The time span of the using animation of the weapon, suggest set it the same as useTime.
-			item.useStyle = 1;			//The use style of weapon, 1 for swinging, 2 for drinking, 3 act like shortsword, 4 for use like life crystal, 5 for use staffs or guns
-			item.knockBack = 6;			//The force of knockback of the weapon. Maximum is 20
-			item.value = 10000;			//The value of the weapon
-			item.rare = 2;				//The rarity of the weapon, from -1 to 13
-			item.UseSound = SoundID.Item1;		//The sound when the weapon is using
-			item.autoReuse = true;			//Whether the weapon can use automatically by pressing mousebutton
+			item.damage = 50;           //The damage of your weapon
+			item.melee = true;          //Is your weapon a melee weapon?
+			item.width = 40;            //Weapon's texture's width
+			item.height = 40;           //Weapon's texture's height
+			item.useTime = 20;          //The time span of using the weapon. Remember in terraria, 60 frames is a second.
+			item.useAnimation = 20;         //The time span of the using animation of the weapon, suggest set it the same as useTime.
+			item.useStyle = 1;          //The use style of weapon, 1 for swinging, 2 for drinking, 3 act like shortsword, 4 for use like life crystal, 5 for use staffs or guns
+			item.knockBack = 6;         //The force of knockback of the weapon. Maximum is 20
+			item.value = Item.buyPrice(gold: 1);           //The value of the weapon
+			item.rare = 2;              //The rarity of the weapon, from -1 to 13
+			item.UseSound = SoundID.Item1;      //The sound when the weapon is using
+			item.autoReuse = true;          //Whether the weapon can use automatically by pressing mousebutton
 		}
 
 		public override void AddRecipes()
@@ -50,7 +50,7 @@ namespace ExampleMod.Items.Weapons
 		{
 			// Add Onfire buff to the NPC for 1 second
 			// 60 frames = 1 second
-			target.AddBuff(BuffID.OnFire, 60);		
+			target.AddBuff(BuffID.OnFire, 60);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -493,9 +493,16 @@ namespace Terraria.ModLoader
 		/// Returns whether the reforge will take place. If false is returned, the PostReforge hook is never called.
 		/// Reforging preserves modded data on the item. 
 		/// </summary>
-		public virtual bool PreReforge(Item item)
+		public virtual bool NewPreReforge(Item item)
 		{
 			return true;
+		}
+
+		// @todo: PreReforge marked obsolete until v0.11
+		[method: Obsolete("PreReforge now returns a bool to control whether the reforge takes place. For now, use NewPreReforge")]
+		public virtual void PreReforge(Item item)
+		{
+			NewPreReforge(item);
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -479,6 +479,16 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Returns if the normal reforge pricing is applied. 
+		/// If true or false is returned and the price is altered, the price will equal the altered price.
+		/// The passed reforge price equals the item.value. Vanilla pricing will apply 20% discount if applicable and then price the reforge at a third of that value.
+		/// </summary>
+		public virtual bool ReforgePrice(Item item, ref int reforgePrice, ref bool canApplyDiscount)
+		{
+			return true;
+		}
+
+		/// <summary>
 		/// This hooks gets called immediately before an item gets reforged by the Goblin Tinkerer. Useful for storing custom data, since reforging erases custom data.
 		/// </summary>
 		public virtual void PreReforge(Item item)

--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -489,14 +489,18 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// This hooks gets called immediately before an item gets reforged by the Goblin Tinkerer. Useful for storing custom data, since reforging erases custom data.
+		/// This hook gets called when the player clicks on the reforge button and can afford the reforge.
+		/// Returns whether the reforge will take place. If false is returned, the PostReforge hook is never called.
+		/// Reforging preserves modded data on the item. 
 		/// </summary>
-		public virtual void PreReforge(Item item)
+		public virtual bool PreReforge(Item item)
 		{
+			return true;
 		}
 
 		/// <summary>
-		/// This hook gets called immediately after an item gets reforged by the Goblin Tinkerer. Useful for restoring custom data that you saved in PreReforge.
+		/// This hook gets called immediately after an item gets reforged by the Goblin Tinkerer.
+		/// Useful for modifying modded data based on the reforge result.
 		/// </summary>
 		public virtual void PostReforge(Item item)
 		{

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -1009,6 +1009,21 @@ namespace Terraria.ModLoader
 				g.OpenVanillaBag(context, player, arg);
 		}
 
+		private delegate bool DelegateReforgePrice(Item item, ref int reforgePrice, ref bool canApplyDiscount);
+		private static HookList HookReforgePrice = AddHook<DelegateReforgePrice>(g => g.ReforgePrice);
+		/// <summary>
+		/// Call all ModItem.ReforgePrice, then GlobalItem.ReforgePrice hooks.
+		/// </summary>
+		/// <param name="canApplyDiscount"></param>
+		/// <returns></returns>
+		public static bool ReforgePrice(Item item, ref int reforgePrice, ref bool canApplyDiscount)
+		{
+			bool b = item.modItem?.ReforgePrice(ref reforgePrice, ref canApplyDiscount) ?? true;
+			foreach (var g in HookReforgePrice.arr)
+				b &= g.Instance(item).ReforgePrice(item, ref reforgePrice, ref canApplyDiscount);
+			return b;
+		}
+
 		private static HookList HookPreReforge = AddHook<Action<Item>>(g => g.PreReforge);
 		/// <summary>
 		/// Calls ModItem.PreReforge, then all GlobalItem.PreReforge hooks.

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -1024,15 +1024,16 @@ namespace Terraria.ModLoader
 			return b;
 		}
 
-		private static HookList HookPreReforge = AddHook<Action<Item>>(g => g.PreReforge);
+		private static HookList HookPreReforge = AddHook<Func<Item, bool>>(g => g.PreReforge);
 		/// <summary>
 		/// Calls ModItem.PreReforge, then all GlobalItem.PreReforge hooks.
 		/// </summary>
-		public static void PreReforge(Item item)
+		public static bool PreReforge(Item item)
 		{
-			item.modItem?.PreReforge();
+			bool b = item.modItem?.PreReforge() ?? true;
 			foreach (var g in HookPreReforge.arr)
-				g.Instance(item).PreReforge(item);
+				b &= g.Instance(item).PreReforge(item);
+			return b;
 		}
 
 		private static HookList HookPostReforge = AddHook<Action<Item>>(g => g.PostReforge);

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -1024,15 +1024,16 @@ namespace Terraria.ModLoader
 			return b;
 		}
 
-		private static HookList HookPreReforge = AddHook<Func<Item, bool>>(g => g.PreReforge);
+		// @todo: PreReforge marked obsolete until v0.11
+		private static HookList HookPreReforge = AddHook<Func<Item, bool>>(g => g.NewPreReforge);
 		/// <summary>
 		/// Calls ModItem.PreReforge, then all GlobalItem.PreReforge hooks.
 		/// </summary>
 		public static bool PreReforge(Item item)
 		{
-			bool b = item.modItem?.PreReforge() ?? true;
+			bool b = item.modItem?.NewPreReforge() ?? true;
 			foreach (var g in HookPreReforge.arr)
-				b &= g.Instance(item).PreReforge(item);
+				b &= g.Instance(item).NewPreReforge(item);
 			return b;
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModItem.cs
@@ -597,6 +597,16 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Returns if the normal reforge pricing is applied. 
+		/// If true or false is returned and the price is altered, the price will equal the altered price.
+		/// The passed reforge price equals the item.value. Vanilla pricing will apply 20% discount if applicable and then price the reforge at a third of that value.
+		/// </summary>
+		public virtual bool ReforgePrice(ref int reforgePrice, ref bool canApplyDiscount)
+		{
+			return true;
+		}
+
+		/// <summary>
 		/// This hooks gets called immediately before an item gets reforged by the Goblin Tinkerer. Useful for storing custom data, since reforging erases custom data. Note that, because the ModItem instance will change, the data must be backed up elsewhere, such as in static fields.
 		/// </summary>
 		public virtual void PreReforge()

--- a/patches/tModLoader/Terraria.ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModItem.cs
@@ -611,9 +611,16 @@ namespace Terraria.ModLoader
 		/// Returns whether the reforge will take place. If false is returned, the PostReforge hook is never called.
 		/// Reforging preserves modded data on the item. 
 		/// </summary
-		public virtual bool PreReforge()
+		public virtual bool NewPreReforge()
 		{
 			return true;
+		}
+
+		// @todo: PreReforge marked obsolete until v0.11
+		[method: Obsolete("PreReforge now returns a bool to control whether the reforge takes place. For now, use NewPreReforge")]
+		public virtual void PreReforge()
+		{
+			item.modItem?.NewPreReforge();
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria.ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModItem.cs
@@ -607,14 +607,18 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// This hooks gets called immediately before an item gets reforged by the Goblin Tinkerer. Useful for storing custom data, since reforging erases custom data. Note that, because the ModItem instance will change, the data must be backed up elsewhere, such as in static fields.
-		/// </summary>
-		public virtual void PreReforge()
+		/// This hook gets called when the player clicks on the reforge button and can afford the reforge.
+		/// Returns whether the reforge will take place. If false is returned, the PostReforge hook is never called.
+		/// Reforging preserves modded data on the item. 
+		/// </summary
+		public virtual bool PreReforge()
 		{
+			return true;
 		}
 
 		/// <summary>
-		/// This hook gets called immediately after an item gets reforged by the Goblin Tinkerer. Useful for restoring custom data that you saved in PreReforge.
+		/// This hook gets called immediately after an item gets reforged by the Goblin Tinkerer.
+		/// Useful for modifying modded data based on the reforge result.
 		/// </summary>
 		public virtual void PostReforge()
 		{

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -263,7 +263,7 @@
  					if (num3 < (float)NPC.sWidth && num3 < num2)
  					{
  						num2 = num3;
-@@ -43998,7 +_,10 @@
+@@ -43998,7 +_,18 @@
  
  		public Item Clone()
  		{
@@ -271,6 +271,14 @@
 +			Item newItem = (Item)base.MemberwiseClone();
 +			newItem.modItem = modItem?.Clone(newItem);
 +			newItem.globalItems = globalItems.Select(g => g.Clone(this, newItem)).ToArray();
++			return newItem;
++		}
++
++		public Item CloneWithModdedData(Item dataSource)
++		{
++			Item newItem = (Item)base.MemberwiseClone();
++			newItem.modItem = modItem?.Clone(newItem);
++			newItem.globalItems = dataSource.globalItems.Select(g => g.Clone(dataSource, newItem)).ToArray();
 +			return newItem;
  		}
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3239,7 +3239,7 @@
  					}
  				}
  			}
-@@ -36521,12 +_,25 @@
+@@ -36521,12 +_,18 @@
  					string text2 = Lang.inter[46].Value + ": ";
  					if (Main.reforgeItem.type > 0)
  					{
@@ -3250,21 +3250,14 @@
 -							num62 = (int)((double)num62 * 0.8);
 -						}
 -						num62 /= 3;
-+						int modifiablePrice = Main.reforgeItem.value;
 +
-+						if (ItemLoader.ReforgePrice(Main.reforgeItem, ref modifiablePrice, ref canApplyDiscount))
++						if (ItemLoader.ReforgePrice(Main.reforgeItem, ref num62, ref canApplyDiscount))
 +						{
-+							num62 = modifiablePrice;
-+
 +							if (canApplyDiscount && Main.player[Main.myPlayer].discount)
 +							{
 +								num62 = (int)((double)num62 * 0.8);
 +							}
 +							num62 /= 3;
-+						}
-+						else
-+						{
-+							num62 = modifiablePrice;
 +						}
 +
  						string text3 = "";

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3239,7 +3239,7 @@
  					}
  				}
  			}
-@@ -36521,12 +_,29 @@
+@@ -36521,12 +_,25 @@
  					string text2 = Lang.inter[46].Value + ": ";
  					if (Main.reforgeItem.type > 0)
  					{
@@ -3251,14 +3251,10 @@
 -						}
 -						num62 /= 3;
 +						int modifiablePrice = Main.reforgeItem.value;
-+						bool canApplyVanillaPrice = ItemLoader.ReforgePrice(Main.reforgeItem, ref modifiablePrice, ref canApplyDiscount);
 +
-+						if (canApplyVanillaPrice)
++						if (ItemLoader.ReforgePrice(Main.reforgeItem, ref modifiablePrice, ref canApplyDiscount))
 +						{
-+							if (modifiablePrice != num62)
-+							{
-+								num62 = modifiablePrice;
-+							}
++							num62 = modifiablePrice;
 +
 +							if (canApplyDiscount && Main.player[Main.myPlayer].discount)
 +							{
@@ -3266,7 +3262,7 @@
 +							}
 +							num62 /= 3;
 +						}
-+						else if (modifiablePrice != num62)
++						else
 +						{
 +							num62 = modifiablePrice;
 +						}
@@ -3274,14 +3270,6 @@
  						string text3 = "";
  						int num63 = 0;
  						int num64 = 0;
-@@ -36556,6 +_,7 @@
- 						{
- 							num66 = num67;
- 						}
-+						// after this point we draw the gold values
- 						if (num63 > 0)
- 						{
- 							object obj = text3;
 @@ -36637,14 +_,17 @@
  							}
  							Main.mouseReforge = true;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3239,6 +3239,57 @@
  					}
  				}
  			}
+@@ -36521,12 +_,29 @@
+ 					string text2 = Lang.inter[46].Value + ": ";
+ 					if (Main.reforgeItem.type > 0)
+ 					{
++						bool canApplyDiscount = true;
+ 						int num62 = Main.reforgeItem.value;
+-						if (Main.player[Main.myPlayer].discount)
+-						{
+-							num62 = (int)((double)num62 * 0.8);
+-						}
+-						num62 /= 3;
++						int modifiablePrice = Main.reforgeItem.value;
++						bool canApplyVanillaPrice = ItemLoader.ReforgePrice(Main.reforgeItem, ref modifiablePrice, ref canApplyDiscount);
++
++						if (canApplyVanillaPrice)
++						{
++							if (modifiablePrice != num62)
++							{
++								num62 = modifiablePrice;
++							}
++
++							if (canApplyDiscount && Main.player[Main.myPlayer].discount)
++							{
++								num62 = (int)((double)num62 * 0.8);
++							}
++							num62 /= 3;
++						}
++						else if (modifiablePrice != num62)
++						{
++							num62 = modifiablePrice;
++						}
++
+ 						string text3 = "";
+ 						int num63 = 0;
+ 						int num64 = 0;
+@@ -36556,6 +_,7 @@
+ 						{
+ 							num66 = num67;
+ 						}
++						// after this point we draw the gold values
+ 						if (num63 > 0)
+ 						{
+ 							object obj = text3;
+@@ -36630,6 +_,7 @@
+ 						UILinkPointNavigator.SetPosition(304, new Vector2((float)num68, (float)num69) + texture2D3.Size() / 4f);
+ 						if (flag8)
+ 						{
++							// we are reforging! 
+ 							Main.hoverItemName = Lang.inter[19].Value;
+ 							if (!Main.mouseReforge)
+ 							{
 @@ -36640,11 +_,13 @@
  							if (Main.mouseLeftRelease && Main.mouseLeft && Main.player[Main.myPlayer].BuyItem(num62, -1))
  							{

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3282,21 +3282,20 @@
  						if (num63 > 0)
  						{
  							object obj = text3;
-@@ -36630,6 +_,7 @@
- 						UILinkPointNavigator.SetPosition(304, new Vector2((float)num68, (float)num69) + texture2D3.Size() / 4f);
- 						if (flag8)
- 						{
-+							// we are reforging! 
- 							Main.hoverItemName = Lang.inter[19].Value;
- 							if (!Main.mouseReforge)
- 							{
-@@ -36640,11 +_,13 @@
- 							if (Main.mouseLeftRelease && Main.mouseLeft && Main.player[Main.myPlayer].BuyItem(num62, -1))
+@@ -36637,14 +_,17 @@
+ 							}
+ 							Main.mouseReforge = true;
+ 							Main.player[Main.myPlayer].mouseInterface = true;
+-							if (Main.mouseLeftRelease && Main.mouseLeft && Main.player[Main.myPlayer].BuyItem(num62, -1))
++							if (Main.mouseLeftRelease && Main.mouseLeft && Main.player[Main.myPlayer].BuyItem(num62, -1) && ItemLoader.PreReforge(Main.reforgeItem))
  							{
  								bool favorited = Main.reforgeItem.favorited;
-+								ItemLoader.PreReforge(Main.reforgeItem);
- 								Main.reforgeItem.netDefaults(Main.reforgeItem.netID);
- 								Main.reforgeItem.Prefix(-2);
+-								Main.reforgeItem.netDefaults(Main.reforgeItem.netID);
+-								Main.reforgeItem.Prefix(-2);
++								Item reforgeItem = new Item();
++								reforgeItem.netDefaults(Main.reforgeItem.netID);
++								reforgeItem.Prefix(-2);
++								Main.reforgeItem = reforgeItem.CloneWithModdedData(Main.reforgeItem);
  								Main.reforgeItem.position.X = Main.player[Main.myPlayer].position.X + (float)(Main.player[Main.myPlayer].width / 2) - (float)(Main.reforgeItem.width / 2);
  								Main.reforgeItem.position.Y = Main.player[Main.myPlayer].position.Y + (float)(Main.player[Main.myPlayer].height / 2) - (float)(Main.reforgeItem.height / 2);
  								Main.reforgeItem.favorited = favorited;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3263,13 +3263,15 @@
  						string text3 = "";
  						int num63 = 0;
  						int num64 = 0;
-@@ -36637,14 +_,17 @@
+@@ -36637,14 +_,18 @@
  							}
  							Main.mouseReforge = true;
  							Main.player[Main.myPlayer].mouseInterface = true;
 -							if (Main.mouseLeftRelease && Main.mouseLeft && Main.player[Main.myPlayer].BuyItem(num62, -1))
-+							if (Main.mouseLeftRelease && Main.mouseLeft && Main.player[Main.myPlayer].BuyItem(num62, -1) && ItemLoader.PreReforge(Main.reforgeItem))
- 							{
+-							{
++							if (Main.mouseLeftRelease && Main.mouseLeft && Main.player[Main.myPlayer].CanBuyItem(num62, -1) && ItemLoader.PreReforge(Main.reforgeItem))
++							{
++								Main.player[Main.myPlayer].BuyItem(num62, -1);
  								bool favorited = Main.reforgeItem.favorited;
 -								Main.reforgeItem.netDefaults(Main.reforgeItem.netID);
 -								Main.reforgeItem.Prefix(-2);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3371,6 +3371,45 @@
  						{
  							float num3 = 12f;
  							Vector2 vector = new Vector2(Main.item[j].position.X + (float)(Main.item[j].width / 2), Main.item[j].position.Y + (float)(Main.item[j].height / 2));
+@@ -26430,6 +_,38 @@
+ 				{
+ 					this.inventory[num5] = array[num5].Clone();
+ 				}
++				return false;
++			}
++			return true;
++		}
++
++		public bool CanBuyItem(int price, int customCurrency = -1)
++		{
++			if (customCurrency != -1)
++			{
++				return CustomCurrencyManager.BuyItem(this, price, customCurrency);
++			}
++			bool flag;
++			long num = Utils.CoinsCount(out flag, this.inventory, new int[]
++			{
++				58,
++				57,
++				56,
++				55,
++				54
++			});
++			long num2 = Utils.CoinsCount(out flag, this.bank.item, new int[0]);
++			long num3 = Utils.CoinsCount(out flag, this.bank2.item, new int[0]);
++			long num4 = Utils.CoinsCount(out flag, this.bank3.item, new int[0]);
++			long num5 = Utils.CoinsCombineStacks(out flag, new long[]
++			{
++				num,
++				num2,
++				num3,
++				num4
++			});
++			if (num5 < (long)price)
++			{
+ 				return false;
+ 			}
+ 			return true;
 @@ -26899,7 +_,7 @@
  		{
  			int num = 4;


### PR DESCRIPTION
**Added** a ReforgePrice hook available to adjust the reforge pricing. The `reforgePrice` can be changed to override the price, `canApplyDiscount` can be set to false to never apply discount. Returning false will stop the vanilla pricing to take place and the price will be set to `reforgePrice`. The passed `reforgePrice` is `item.value` (as Terraria uses that as the base price). Returns true by default so vanilla pricing takes place. This hook will be useful to adjust reforge pricing without touching the actual item value.

**Adjusted** the PreReforge hook to return a bool.  Returns whether the reforge will take place. If false is returned, the PostReforge hook is never called because the reforge will not happen. Returns true by default.

**Changed** the reforge code slightly so any modded data on the item being reforged will be preserved. This means modders no longer have to manually preserve their modded data with PreReforge and PostReforge, provided they've setup their Clone override properly.

Personally I'll be using the changes for the Even More Modifiers mod. The reforge price will be adjusted based on the modifier rarity. Possibly, I will let reforging interact with the modifiers.