### PR TITLE
Added middle mouse, xbutton1, and xbutton2 support

### DIFF
--- a/patches/tModLoader/Terraria.GameContent.UI.Elements/UIKeybindingListItem.cs.patch
+++ b/patches/tModLoader/Terraria.GameContent.UI.Elements/UIKeybindingListItem.cs.patch
@@ -1,0 +1,16 @@
+--- src/Terraria\Terraria.GameContent.UI.Elements\UIKeybindingListItem.cs
++++ src/tModLoader\Terraria.GameContent.UI.Elements\UIKeybindingListItem.cs
+@@ -115,6 +_,12 @@
+ 					return Lang.menu[162].Value;
+ 				case "MouseRight":
+ 					return Lang.menu[163].Value;
++				case "MouseMiddle":
++					return Language.GetTextValue("tModLoader.MouseMiddle");
++				case "MouseXButton1":
++					return Language.GetTextValue("tModLoader.MouseXButton1");
++				case "MouseXButton2":
++					return Language.GetTextValue("tModLoader.MouseXButton2");
+ 				case "Up":
+ 					return Lang.menu[148].Value;
+ 				case "Down":
+

--- a/patches/tModLoader/Terraria.GameContent.UI.States/UIManageControls.cs.patch
+++ b/patches/tModLoader/Terraria.GameContent.UI.States/UIManageControls.cs.patch
@@ -22,6 +22,26 @@
  		private bool OnKeyboard = true;
  		private bool OnGameplay = true;
  		private List<UIElement> _bindsKeyboard = new List<UIElement>();
+@@ -207,6 +_,9 @@
+ 			{
+ 				"MouseLeft",
+ 				"MouseRight",
++				"MouseMiddle",
++				"MouseXButton1",
++				"MouseXButton2",
+ 				"Up",
+ 				"Down",
+ 				"Left",
+@@ -229,6 +_,9 @@
+ 			{
+ 				"MouseLeft",
+ 				"MouseRight",
++				"MouseMiddle",
++				"MouseXButton1",
++				"MouseXButton2",
+ 				"Up",
+ 				"Down",
+ 				"Left",
 @@ -296,26 +_,39 @@
  				"sp19",
  				"sp13"

--- a/patches/tModLoader/Terraria.GameInput/PlayerInput.cs.patch
+++ b/patches/tModLoader/Terraria.GameInput/PlayerInput.cs.patch
@@ -8,6 +8,16 @@
  using Terraria.Social;
  using Terraria.UI;
  using Terraria.UI.Gamepad;
+@@ -26,6 +_,9 @@
+ 		{
+ 			"MouseLeft",
+ 			"MouseRight",
++			"MouseMiddle",
++			"MouseXButton1",
++			"MouseXButton2",
+ 			"Up",
+ 			"Down",
+ 			"Left",
 @@ -332,6 +_,42 @@
  			}
  		}
@@ -51,6 +61,17 @@
  		public static void Initialize()
  		{
  			Main.InputProfiles.OnProcessText += new Preferences.TextProcessAction(PlayerInput.PrettyPrintProfiles);
+@@ -521,6 +_,10 @@
+ 			PlayerInput.UpdateMainMouse();
+ 			Main.mouseLeft = PlayerInput.Triggers.Current.MouseLeft;
+ 			Main.mouseRight = PlayerInput.Triggers.Current.MouseRight;
++			Main.mouseMiddle = PlayerInput.Triggers.Current.MouseMiddle;
++			Main.mouseXButton1 = PlayerInput.Triggers.Current.MouseXButton1;
++			Main.mouseXButton2 = PlayerInput.Triggers.Current.MouseXButton2;
++			
+ 			PlayerInput.CacheZoomableValues();
+ 		}
+ 
 @@ -735,6 +_,8 @@
  				keyConfiguration.Processkey(PlayerInput.Triggers.Current, Buttons.RightTrigger.ToString());
  				flag = true;
@@ -60,6 +81,16 @@
  			bool flag4 = ItemID.Sets.GamepadWholeScreenUseRange[player.inventory[player.selectedItem].type] || player.scope;
  			int num3 = player.inventory[player.selectedItem].tileBoost + ItemID.Sets.GamepadExtraRange[player.inventory[player.selectedItem].type];
  			if (player.yoyoString && ItemID.Sets.Yoyo[player.inventory[player.selectedItem].type])
+@@ -1041,6 +_,9 @@
+ 			{
+ 				"MouseLeft",
+ 				"MouseRight",
++				"MouseMiddle",
++				"MouseXButton1",
++				"MouseXButton2",
+ 				"Inventory"
+ 			};
+ 			foreach (InputMode inputMode in Enum.GetValues(typeof(InputMode)))
 @@ -1218,7 +_,7 @@
  						int num = 6;
  						if (ItemSlot.IsABuildingItem(player.inventory[player.selectedItem]))
@@ -69,7 +100,17 @@
  						}
  						PlayerInput.DpadSnapCooldown[i] = num;
  						value += value2;
-@@ -1524,6 +_,10 @@
+@@ -1493,6 +_,9 @@
+ 						case InputMode.Keyboard:
+ 							c.KeyStatus["MouseLeft"].Add("Mouse1");
+ 							c.KeyStatus["MouseRight"].Add("Mouse2");
++							c.KeyStatus["MouseMiddle"].Add("Mouse3");
++							c.KeyStatus["MouseXButton1"].Add("Mouse4");
++							c.KeyStatus["MouseXButton2"].Add("Mouse5");
+ 							c.KeyStatus["Up"].Add("W");
+ 							c.KeyStatus["Down"].Add("S");
+ 							c.KeyStatus["Left"].Add("A");
+@@ -1524,11 +_,18 @@
  							c.KeyStatus["Hotbar10"].Add("D0");
  							c.KeyStatus["ViewZoomOut"].Add("OemMinus");
  							c.KeyStatus["ViewZoomIn"].Add("OemPlus");
@@ -80,7 +121,25 @@
  							return;
  						case InputMode.KeyboardUI:
  							c.KeyStatus["MouseLeft"].Add("Mouse1");
-@@ -1634,6 +_,10 @@
+ 							c.KeyStatus["MouseLeft"].Add("Space");
+ 							c.KeyStatus["MouseRight"].Add("Mouse2");
++							c.KeyStatus["MouseMiddle"].Add("Mouse3");
++							c.KeyStatus["MouseXButton1"].Add("Mouse4");
++							c.KeyStatus["MouseXButton2"].Add("Mouse5");
+ 							c.KeyStatus["Up"].Add("W");
+ 							c.KeyStatus["Up"].Add("Up");
+ 							c.KeyStatus["Down"].Add("S");
+@@ -1603,6 +_,9 @@
+ 						case InputMode.Keyboard:
+ 							c.KeyStatus["MouseLeft"].Add("Mouse1");
+ 							c.KeyStatus["MouseRight"].Add("Mouse2");
++							c.KeyStatus["MouseMiddle"].Add("Mouse3");
++							c.KeyStatus["MouseXButton1"].Add("Mouse4");
++							c.KeyStatus["MouseXButton2"].Add("Mouse5");
+ 							c.KeyStatus["Up"].Add("W");
+ 							c.KeyStatus["Down"].Add("S");
+ 							c.KeyStatus["Left"].Add("A");
+@@ -1634,11 +_,18 @@
  							c.KeyStatus["Hotbar10"].Add("D0");
  							c.KeyStatus["ViewZoomOut"].Add("OemMinus");
  							c.KeyStatus["ViewZoomIn"].Add("OemPlus");
@@ -91,7 +150,25 @@
  							return;
  						case InputMode.KeyboardUI:
  							c.KeyStatus["MouseLeft"].Add("Mouse1");
-@@ -1743,6 +_,10 @@
+ 							c.KeyStatus["MouseLeft"].Add("Space");
+ 							c.KeyStatus["MouseRight"].Add("Mouse2");
++							c.KeyStatus["MouseMiddle"].Add("Mouse3");
++							c.KeyStatus["MouseXButton1"].Add("Mouse4");
++							c.KeyStatus["MouseXButton2"].Add("Mouse5");
+ 							c.KeyStatus["Up"].Add("W");
+ 							c.KeyStatus["Up"].Add("Up");
+ 							c.KeyStatus["Down"].Add("S");
+@@ -1712,6 +_,9 @@
+ 						case InputMode.Keyboard:
+ 							c.KeyStatus["MouseLeft"].Add("Mouse1");
+ 							c.KeyStatus["MouseRight"].Add("Mouse2");
++							c.KeyStatus["MouseMiddle"].Add("Mouse3");
++							c.KeyStatus["MouseXButton1"].Add("Mouse4");
++							c.KeyStatus["MouseXButton2"].Add("Mouse5");
+ 							c.KeyStatus["Up"].Add("W");
+ 							c.KeyStatus["Down"].Add("S");
+ 							c.KeyStatus["Left"].Add("A");
+@@ -1743,11 +_,18 @@
  							c.KeyStatus["Hotbar10"].Add("D0");
  							c.KeyStatus["ViewZoomOut"].Add("OemMinus");
  							c.KeyStatus["ViewZoomIn"].Add("OemPlus");
@@ -102,7 +179,25 @@
  							return;
  						case InputMode.KeyboardUI:
  							c.KeyStatus["MouseLeft"].Add("Mouse1");
-@@ -1852,6 +_,10 @@
+ 							c.KeyStatus["MouseLeft"].Add("Space");
+ 							c.KeyStatus["MouseRight"].Add("Mouse2");
++							c.KeyStatus["MouseMiddle"].Add("Mouse3");
++							c.KeyStatus["MouseXButton1"].Add("Mouse4");
++							c.KeyStatus["MouseXButton2"].Add("Mouse5");
+ 							c.KeyStatus["Up"].Add("W");
+ 							c.KeyStatus["Up"].Add("Up");
+ 							c.KeyStatus["Down"].Add("S");
+@@ -1821,6 +_,9 @@
+ 						case InputMode.Keyboard:
+ 							c.KeyStatus["MouseLeft"].Add("Mouse1");
+ 							c.KeyStatus["MouseRight"].Add("Mouse2");
++							c.KeyStatus["MouseMiddle"].Add("Mouse3");
++							c.KeyStatus["MouseXButton1"].Add("Mouse4");
++							c.KeyStatus["MouseXButton2"].Add("Mouse5");
+ 							c.KeyStatus["Up"].Add("W");
+ 							c.KeyStatus["Down"].Add("S");
+ 							c.KeyStatus["Left"].Add("A");
+@@ -1852,11 +_,18 @@
  							c.KeyStatus["Hotbar10"].Add("D0");
  							c.KeyStatus["ViewZoomOut"].Add("OemMinus");
  							c.KeyStatus["ViewZoomIn"].Add("OemPlus");
@@ -113,4 +208,12 @@
  							return;
  						case InputMode.KeyboardUI:
  							c.KeyStatus["MouseLeft"].Add("Mouse1");
+ 							c.KeyStatus["MouseLeft"].Add("Space");
+ 							c.KeyStatus["MouseRight"].Add("Mouse2");
++							c.KeyStatus["MouseMiddle"].Add("Mouse3");
++							c.KeyStatus["MouseXButton1"].Add("Mouse4");
++							c.KeyStatus["MouseXButton2"].Add("Mouse5");
+ 							c.KeyStatus["Up"].Add("W");
+ 							c.KeyStatus["Up"].Add("Up");
+ 							c.KeyStatus["Down"].Add("S");
 

--- a/patches/tModLoader/Terraria.GameInput/PlayerInputProfile.cs.patch
+++ b/patches/tModLoader/Terraria.GameInput/PlayerInputProfile.cs.patch
@@ -17,6 +17,16 @@
  			dictionary2.Add("Edittable", this.AllowEditting);
  			dictionary2.Add("Gamepad - HotbarRadialHoldTime", this.HotbarRadialHoldTimeRequired);
  			dictionary2.Add("Gamepad - LeftThumbstickDeadzoneX", this.LeftThumbstickDeadzoneX);
+@@ -238,6 +_,9 @@
+ 			{
+ 				"MouseLeft",
+ 				"MouseRight",
++				"MouseMiddle",
++				"MouseXButton1",
++				"MouseXButton2",
+ 				"Up",
+ 				"Down",
+ 				"Left",
 @@ -292,6 +_,18 @@
  			this.CopyKeysFrom(profile, mode, keysToCopy);
  		}

--- a/patches/tModLoader/Terraria.GameInput/TriggerNames.cs.patch
+++ b/patches/tModLoader/Terraria.GameInput/TriggerNames.cs.patch
@@ -1,0 +1,13 @@
+--- src/Terraria\Terraria.GameInput\TriggerNames.cs
++++ src/tModLoader\Terraria.GameInput\TriggerNames.cs
+@@ -6,6 +_,9 @@
+ 	{
+ 		public const string MouseLeft = "MouseLeft";
+ 		public const string MouseRight = "MouseRight";
++		public const string MouseMiddle = "MouseMiddle";
++		public const string MouseXButton1 = "MouseXButton1";
++		public const string MouseXButton2 = "MouseXButton2";
+ 		public const string Up = "Up";
+ 		public const string Down = "Down";
+ 		public const string Left = "Left";
+

--- a/patches/tModLoader/Terraria.GameInput/TriggersSet.cs.patch
+++ b/patches/tModLoader/Terraria.GameInput/TriggersSet.cs.patch
@@ -1,5 +1,48 @@
 --- src/Terraria\Terraria.GameInput\TriggersSet.cs
 +++ src/tModLoader\Terraria.GameInput\TriggersSet.cs
+@@ -36,6 +_,42 @@
+ 			}
+ 		}
+ 
++		public bool MouseMiddle
++		{
++			get
++			{
++				return this.KeyStatus["MouseMiddle"];
++			}
++			set
++			{
++				this.KeyStatus["MouseMiddle"] = value;
++			}
++		}
++
++		public bool MouseXButton1
++		{
++			get
++			{
++				return this.KeyStatus["MouseXButton1"];
++			}
++			set
++			{
++				this.KeyStatus["MouseXButton1"] = value;
++			}
++		}
++
++		public bool MouseXButton2
++		{
++			get
++			{
++				return this.KeyStatus["MouseXButton2"];
++			}
++			set
++			{
++				this.KeyStatus["MouseXButton2"] = value;
++			}
++		}
++
+ 		public bool Up
+ 		{
+ 			get
 @@ -660,6 +_,10 @@
  			foreach (string current in PlayerInput.KnownTriggers)
  			{

--- a/patches/tModLoader/Terraria.Localization.Content.en-US.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.en-US.tModLoader.json
@@ -72,5 +72,10 @@
 		"MSIntializing": "Initializing: ",
 		//There should be ModName after ':'
 		"MSLoading": "Loading Mod: ",
+
+		// Extra mouse buttons
+		"MouseMiddle": "Middle Mouse",
+		"MouseXButton1": "Mouse 4",
+		"MouseXButton2": "Mouse 5",
 	}
 }

--- a/patches/tModLoader/Terraria.UI/UIElement.cs.patch
+++ b/patches/tModLoader/Terraria.UI/UIElement.cs.patch
@@ -1,6 +1,14 @@
 --- src/Terraria\Terraria.UI\UIElement.cs
 +++ src/tModLoader\Terraria.UI\UIElement.cs
-@@ -49,6 +_,10 @@
+@@ -42,13 +_,29 @@
+ 		protected bool _useImmediateMode;
+ 		private SnapPoint _snapPoint;
+ 		private bool _isMouseHovering;
+-
++		
+ 		public event UIElement.MouseEvent OnMouseDown;
+ 		public event UIElement.MouseEvent OnMouseUp;
+ 		public event UIElement.MouseEvent OnClick;
  		public event UIElement.MouseEvent OnMouseOver;
  		public event UIElement.MouseEvent OnMouseOut;
  		public event UIElement.MouseEvent OnDoubleClick;
@@ -8,6 +16,18 @@
 +		public event UIElement.MouseEvent OnRightMouseUp;
 +		public event UIElement.MouseEvent OnRightClick;
 +		public event UIElement.MouseEvent OnRightDoubleClick;
++		public event UIElement.MouseEvent OnMiddleMouseDown;
++		public event UIElement.MouseEvent OnMiddleMouseUp;
++		public event UIElement.MouseEvent OnMiddleClick;
++		public event UIElement.MouseEvent OnMiddleDoubleClick;
++		public event UIElement.MouseEvent OnXButton1MouseDown;
++		public event UIElement.MouseEvent OnXButton1MouseUp;
++		public event UIElement.MouseEvent OnXButton1Click;
++		public event UIElement.MouseEvent OnXButton1DoubleClick;
++		public event UIElement.MouseEvent OnXButton2MouseDown;
++		public event UIElement.MouseEvent OnXButton2MouseUp;
++		public event UIElement.MouseEvent OnXButton2Click;
++		public event UIElement.MouseEvent OnXButton2DoubleClick;
  		public event UIElement.ScrollWheelEvent OnScrollWheel;
  
  		public bool IsMouseHovering
@@ -23,7 +43,7 @@
  		}
  
  		public virtual void Draw(SpriteBatch spriteBatch)
-@@ -404,6 +_,54 @@
+@@ -404,6 +_,198 @@
  			}
  		}
  
@@ -72,6 +92,150 @@
 +			if (this.Parent != null)
 +			{
 +				this.Parent.RightDoubleClick(evt);
++			}
++		}
++
++		public virtual void MiddleMouseDown(UIMouseEvent evt)
++		{
++			if (this.OnMiddleMouseDown != null)
++			{
++				this.OnMiddleMouseDown(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.MiddleMouseDown(evt);
++			}
++		}
++
++		public virtual void MiddleMouseUp(UIMouseEvent evt)
++		{
++			if (this.OnMiddleMouseUp != null)
++			{
++				this.OnMiddleMouseUp(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.MiddleMouseUp(evt);
++			}
++		}
++
++		public virtual void MiddleClick(UIMouseEvent evt)
++		{
++			if (this.OnMiddleClick != null)
++			{
++				this.OnMiddleClick(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.MiddleClick(evt);
++			}
++		}
++
++		public virtual void MiddleDoubleClick(UIMouseEvent evt)
++		{
++			if (this.OnMiddleDoubleClick != null)
++			{
++				this.OnMiddleDoubleClick(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.MiddleDoubleClick(evt);
++			}
++		}
++
++		public virtual void XButton1MouseDown(UIMouseEvent evt)
++		{
++			if (this.OnXButton1MouseDown != null)
++			{
++				this.OnXButton1MouseDown(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.XButton1MouseDown(evt);
++			}
++		}
++
++		public virtual void XButton1MouseUp(UIMouseEvent evt)
++		{
++			if (this.OnXButton1MouseUp != null)
++			{
++				this.OnXButton1MouseUp(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.XButton1MouseUp(evt);
++			}
++		}
++
++		public virtual void XButton1Click(UIMouseEvent evt)
++		{
++			if (this.OnXButton1Click != null)
++			{
++				this.OnXButton1Click(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.XButton1Click(evt);
++			}
++		}
++
++		public virtual void XButton1DoubleClick(UIMouseEvent evt)
++		{
++			if (this.OnXButton1DoubleClick != null)
++			{
++				this.OnXButton1DoubleClick(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.XButton1DoubleClick(evt);
++			}
++		}
++
++		public virtual void XButton2MouseDown(UIMouseEvent evt)
++		{
++			if (this.OnXButton2MouseDown != null)
++			{
++				this.OnXButton2MouseDown(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.XButton2MouseDown(evt);
++			}
++		}
++
++		public virtual void XButton2MouseUp(UIMouseEvent evt)
++		{
++			if (this.OnXButton2MouseUp != null)
++			{
++				this.OnXButton2MouseUp(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.XButton2MouseUp(evt);
++			}
++		}
++
++		public virtual void XButton2Click(UIMouseEvent evt)
++		{
++			if (this.OnXButton2Click != null)
++			{
++				this.OnXButton2Click(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.XButton2Click(evt);
++			}
++		}
++
++		public virtual void XButton2DoubleClick(UIMouseEvent evt)
++		{
++			if (this.OnXButton2DoubleClick != null)
++			{
++				this.OnXButton2DoubleClick(evt, this);
++			}
++			if (this.Parent != null)
++			{
++				this.Parent.XButton2DoubleClick(evt);
 +			}
 +		}
 +

--- a/patches/tModLoader/Terraria.UI/UserInterface.cs.patch
+++ b/patches/tModLoader/Terraria.UI/UserInterface.cs.patch
@@ -1,17 +1,29 @@
 --- src/Terraria\Terraria.UI\UserInterface.cs
 +++ src/tModLoader\Terraria.UI\UserInterface.cs
-@@ -16,10 +_,14 @@
+@@ -16,10 +_,26 @@
  		private List<UIState> _history = new List<UIState>();
  		public Vector2 MousePosition;
  		private bool _wasMouseDown;
 +		private bool _wasMouseRightDown;
++		private bool _wasMouseMiddleDown;
++		private bool _wasMouseXButton1Down;
++		private bool _wasMouseXButton2Down;
  		private UIElement _lastElementHover;
  		private UIElement _lastElementDown;
 +		private UIElement _lastElementRightDown;
++		private UIElement _lastElementMiddleDown;
++		private UIElement _lastElementXButton1Down;
++		private UIElement _lastElementXButton2Down;
  		private UIElement _lastElementClicked;
 +		private UIElement _lastElementRightClicked;
++		private UIElement _lastElementMiddleClicked;
++		private UIElement _lastElementXButton1Clicked;
++		private UIElement _lastElementXButton2Clicked;
  		private double _lastMouseDownTime;
 +		private double _lastMouseRightDownTime;
++		private double _lastMouseMiddleDownTime;
++		private double _lastMouseXButton1DownTime;
++		private double _lastMouseXButton2DownTime;
  		private double _clickDisabledTimeRemaining;
  		public bool IsVisible;
  		private UIState _currentState;
@@ -25,15 +37,18 @@
  		}
  
  		public UserInterface()
-@@ -60,6 +_,7 @@
+@@ -60,6 +_,10 @@
  #if CLIENT
  			this.MousePosition = new Vector2((float)Main.mouseX, (float)Main.mouseY);
  			this._wasMouseDown = Main.mouseLeft;
 +			this._wasMouseRightDown = Main.mouseRight;
++			this._wasMouseMiddleDown = Main.mouseMiddle;
++			this._wasMouseXButton1Down = Main.mouseXButton1;
++			this._wasMouseXButton2Down = Main.mouseXButton2;
  			if (this._lastElementHover != null)
  			{
  				this._lastElementHover.MouseOut(new UIMouseEvent(this._lastElementHover, this.MousePosition));
-@@ -67,8 +_,11 @@
+@@ -67,8 +_,14 @@
  #endif
  			this._lastElementHover = null;
  			this._lastElementDown = null;
@@ -42,22 +57,28 @@
 +			this._lastElementRightClicked = null;
  			this._lastMouseDownTime = 0.0;
 +			this._lastMouseRightDownTime = 0.0;
++			this._lastMouseMiddleDownTime = 0.0;
++			this._lastMouseXButton1DownTime = 0.0;
++			this._lastMouseXButton2DownTime = 0.0;
  			this._clickDisabledTimeRemaining = Math.Max(this._clickDisabledTimeRemaining, 200.0);
  		}
  
-@@ -78,6 +_,7 @@
+@@ -78,6 +_,10 @@
  			{
  				this.MousePosition = new Vector2((float)Main.mouseX, (float)Main.mouseY);
  				bool flag = Main.mouseLeft && Main.hasFocus;
 +				bool mouseRightDown = Main.mouseRight && Main.hasFocus;
++				bool mouseMiddleDown = Main.mouseMiddle && Main.hasFocus;
++				bool mouseXButton1Down = Main.mouseXButton1 && Main.hasFocus;
++				bool mouseXButton2Down = Main.mouseXButton2 && Main.hasFocus;
  				UIElement uIElement = Main.hasFocus ? this._currentState.GetElementAt(this.MousePosition) : null;
  				this._clickDisabledTimeRemaining = Math.Max(0.0, this._clickDisabledTimeRemaining - time.ElapsedGameTime.TotalMilliseconds);
  				bool flag2 = this._clickDisabledTimeRemaining > 0.0;
-@@ -115,15 +_,39 @@
+@@ -115,15 +_,109 @@
  					lastElementDown.MouseUp(new UIMouseEvent(lastElementDown, this.MousePosition));
  					this._lastElementDown = null;
  				}
-+				// tModLoader added functionality, right click Events
++				// tModLoader added functionality, right, middle, extra button 1 & 2 click Events
 +				if (mouseRightDown && !this._wasMouseRightDown && uIElement != null && !flag2)
 +				{
 +					this._lastElementRightDown = uIElement;
@@ -80,6 +101,73 @@
 +					lastElementRightDown.RightMouseUp(new UIMouseEvent(lastElementRightDown, this.MousePosition));
 +					this._lastElementRightDown = null;
 +				}
++				if(mouseMiddleDown && !this._wasMouseMiddleDown && uIElement != null && !flag2)
++				{
++					this._lastElementMiddleDown = uIElement;
++					uIElement.MiddleMouseDown(new UIMouseEvent(uIElement, this.MousePosition));
++					if(this._lastElementMiddleClicked == uIElement && time.TotalGameTime.TotalMilliseconds - this._lastMouseMiddleDownTime < 500.0)
++					{
++						uIElement.MiddleDoubleClick(new UIMouseEvent(uIElement, this.MousePosition));
++						this._lastElementMiddleClicked = null;
++					}
++					this._lastMouseMiddleDownTime = time.TotalGameTime.TotalMilliseconds;
++				}
++				else if(!mouseMiddleDown && this._wasMouseMiddleDown && this._lastElementMiddleDown != null && !flag2)
++				{
++					UIElement lastElementMiddleDown = this._lastElementMiddleDown;
++					if(lastElementMiddleDown.ContainsPoint(this.MousePosition))
++					{
++						lastElementMiddleDown.MiddleClick(new UIMouseEvent(lastElementMiddleDown, this.MousePosition));
++						this._lastElementMiddleClicked = this._lastElementMiddleDown;
++					}
++					lastElementMiddleDown.MiddleMouseUp(new UIMouseEvent(lastElementMiddleDown, this.MousePosition));
++					this._lastElementMiddleDown = null;
++				}
++				if(mouseXButton1Down && !this._wasMouseXButton1Down && uIElement != null && !flag2)
++				{
++					this._lastElementXButton1Down = uIElement;
++					uIElement.XButton1MouseDown(new UIMouseEvent(uIElement, this.MousePosition));
++					if(this._lastElementXButton1Clicked == uIElement && time.TotalGameTime.TotalMilliseconds - this._lastMouseXButton1DownTime < 500.0)
++					{
++						uIElement.XButton1DoubleClick(new UIMouseEvent(uIElement, this.MousePosition));
++						this._lastElementXButton1Clicked = null;
++					}
++					this._lastMouseXButton1DownTime = time.TotalGameTime.TotalMilliseconds;
++				}
++				else if(!mouseXButton1Down && this._wasMouseXButton1Down && this._lastElementXButton1Down != null && !flag2)
++				{
++					UIElement lastElementXButton1Down = this._lastElementXButton1Down;
++					if(lastElementXButton1Down.ContainsPoint(this.MousePosition))
++					{
++						lastElementXButton1Down.XButton1Click(new UIMouseEvent(lastElementXButton1Down, this.MousePosition));
++						this._lastElementXButton1Clicked = this._lastElementXButton1Down;
++					}
++					lastElementXButton1Down.XButton1MouseUp(new UIMouseEvent(lastElementXButton1Down, this.MousePosition));
++					this._lastElementXButton1Down = null;
++				}
++				if(mouseXButton2Down && !this._wasMouseXButton2Down && uIElement != null && !flag2)
++				{
++					this._lastElementXButton2Down = uIElement;
++					uIElement.XButton2MouseDown(new UIMouseEvent(uIElement, this.MousePosition));
++					if(this._lastElementXButton2Clicked == uIElement && time.TotalGameTime.TotalMilliseconds - this._lastMouseXButton2DownTime < 500.0)
++					{
++						uIElement.XButton2DoubleClick(new UIMouseEvent(uIElement, this.MousePosition));
++						this._lastElementXButton2Clicked = null;
++					}
++					this._lastMouseXButton2DownTime = time.TotalGameTime.TotalMilliseconds;
++				}
++				else if(!mouseXButton2Down && this._wasMouseXButton2Down && this._lastElementXButton2Down != null && !flag2)
++				{
++					UIElement lastElementXButton2Down = this._lastElementXButton2Down;
++					if(lastElementXButton2Down.ContainsPoint(this.MousePosition))
++					{
++						lastElementXButton2Down.XButton2Click(new UIMouseEvent(lastElementXButton2Down, this.MousePosition));
++						this._lastElementXButton2Clicked = this._lastElementXButton2Down;
++					}
++					lastElementXButton2Down.XButton2MouseUp(new UIMouseEvent(lastElementXButton2Down, this.MousePosition));
++					this._lastElementXButton2Down = null;
++				}
++
  				if (PlayerInput.ScrollWheelDeltaForUI != 0)
  				{
  					if (uIElement != null)
@@ -91,6 +179,9 @@
  				}
  				this._wasMouseDown = flag;
 +				this._wasMouseRightDown = mouseRightDown;
++				this._wasMouseMiddleDown = mouseMiddleDown;
++				this._wasMouseXButton1Down = mouseXButton1Down;
++				this._wasMouseXButton2Down = mouseXButton2Down;
  				if (this._currentState != null)
  				{
  					this._currentState.Update(time);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -60,6 +60,16 @@
  		public static bool[] hairLoaded = new bool[134];
  		public static bool[] wingsLoaded = new bool[40];
  		public static bool[] goreLoaded = new bool[1087];
+@@ -358,6 +_,9 @@
+ 		public static int lastMouseY;
+ 		public static bool mouseLeft;
+ 		public static bool mouseRight;
++		public static bool mouseMiddle;
++		public static bool mouseXButton1;
++		public static bool mouseXButton2;
+ 		public static bool isMouseLeftConsumedByUI = false;
+ 		public static float essScale = 1f;
+ 		public static int essDir = -1;
 @@ -462,13 +_,13 @@
  		public static int wofB;
  		public static int wofF = 0;
@@ -134,7 +144,7 @@
  		public static float[] musicFade = new float[42];
  		public static float musicVolume = 0.75f;
  		public static float ambientVolume = 0.75f;
-@@ -1221,6 +_,8 @@
+@@ -1221,9 +_,14 @@
  			0.75f
  		};
  		public static byte mouseTextColor = 0;
@@ -143,6 +153,12 @@
  		public static int mouseTextColorChange = 1;
  		public static bool mouseLeftRelease = false;
  		public static bool mouseRightRelease = false;
++		public static bool mouseMiddleRelease = false;
++		public static bool mouseXButton1Release = false;
++		public static bool mouseXButton2Release = false;
+ 		public static bool playerInventory = false;
+ 		public static int stackSplit;
+ 		public static int stackCounter = 0;
 @@ -1334,9 +_,9 @@
  		public static List<WorldFileData> WorldList = new List<WorldFileData>();
  		public static WorldFileData ActiveWorldFileData = new WorldFileData();
@@ -685,6 +701,16 @@
  				if (!Main.gameMenu || Main.netMode == 2)
  				{
  					WorldFile.tempRaining = Main.raining;
+@@ -12258,6 +_,9 @@
+ 					}
+ 					Main.mouseLeftRelease = false;
+ 					Main.mouseRightRelease = false;
++					Main.mouseMiddleRelease = false;
++					Main.mouseXButton1Release = false;
++					Main.mouseXButton2Release = false;
+ 					if (Main.gameMenu)
+ 					{
+ 						Main.UpdateMenu();
 @@ -12435,6 +_,10 @@
  				{
  					flag = true;
@@ -3541,6 +3567,37 @@
  			}
  			Vector2 bonus = Main.DrawThickCursor(false);
  			Main.DrawCursor(bonus, false);
+@@ -46530,6 +_,30 @@
+ 			else
+ 			{
+ 				Main.mouseRightRelease = true;
++			}
++			if (Main.mouseMiddle)
++			{
++				Main.mouseMiddleRelease = false;
++			}
++			else
++			{
++				Main.mouseMiddleRelease = true;
++			}
++			if (Main.mouseXButton1)
++			{
++				Main.mouseXButton1Release = false;
++			}
++			else
++			{
++				Main.mouseXButton1Release = true;
++			}
++			if (Main.mouseXButton2)
++			{
++				Main.mouseXButton2Release = false;
++			}
++			else
++			{
++				Main.mouseXButton2Release = true;
+ 			}
+ 			if (Main.menuMode == num)
+ 			{
 @@ -46812,6 +_,7 @@
  			{
  				num9 = 2;
@@ -3929,6 +3986,37 @@
  				TimeLogger.DetailedDrawTime(35);
  				this.SortDrawCacheWorms();
  				this.DrawCachedProjs(this.DrawCacheProjsBehindProjectiles, true);
+@@ -58021,6 +_,30 @@
+ 				else
+ 				{
+ 					Main.mouseRightRelease = true;
++				}
++				if (Main.mouseMiddle)
++				{
++					Main.mouseMiddleRelease = false;
++				}
++				else
++				{
++					Main.mouseMiddleRelease = true;
++				}
++				if (Main.mouseXButton1)
++				{
++					Main.mouseXButton1Release = false;
++				}
++				else
++				{
++					Main.mouseXButton1Release = true;
++				}
++				if (Main.mouseXButton2)
++				{
++					Main.mouseXButton2Release = false;
++				}
++				else
++				{
++					Main.mouseXButton2Release = true;
+ 				}
+ 				if (!PlayerInput.Triggers.Current.MouseRight)
+ 				{
 @@ -58163,6 +_,7 @@
  			{
  				num3 = 0;


### PR DESCRIPTION
<!-- Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Where applicable, provide Example Mod usage (example code), see the 'Sample usage' section
* If a header/description isn't applicable to your PR, leave it empty or remove it -->

### Description of the Change
This adds support for the middle mouse button and two extra mouse buttons (mouse 4 and 5).

### Why this should be merged into tModLoader
Terraria lacks support for extra mouse buttons, which limits the ability of the game's UI.

### Benefits
This change will allow people to create mods that can use the middle and extra mouse buttons for any reason, whether in a UIElement, an item, etc.

### Possible drawbacks
There should hopefully not be any outside of an increased executable size.

### Sample Usage
Just like with the left and right mouse buttons, you can assign event handlers for the new buttons in a custom UIElement:

```csharp
base.OnMiddleClick += new UIElement.MouseEvent(this.OnMiddleClickMethod);
base.OnXButton1Down += new UIElement.MouseEvent(this.OnXButton1DownMethod);
base.OnXButton2Up += new UIElement.MouseEvent(this.OnXButton2UpMethod);
```

Override them:
```csharp
public override void MiddleClick(UIMouseEvent evt) {
    ...
}

public override void XButton1Down(UIMouseEvent evt) {
    ...
}

public override void XButton2Up(UIMouseEvent evt) {
    ...
}
```

Or use them in a `UIState`:
```csharp
panel = new UIPanel();
panel.OnMiddleClick += Panel_OnMiddleClick;
panel.OnXButton1Down += Panel_OnXButton1Down;
panel.OnXButton2Up += Panel_OnXButton2Up;
```

I'm not quite sure how to do it myself, but since the game now supports the new buttons, a modder can also hook into the input states and add extra functionality to an item, NPC, tile, etc.