### PR TITLE
Allows thrown weapons to have prefixes

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -197,7 +197,7 @@ namespace Terraria.ModLoader
 		//add to Terraria.Item.Prefix
 		internal static bool RangedPrefix(Item item)
 		{
-			return item.modItem != null && GeneralPrefix(item) && item.ranged;
+			return item.modItem != null && GeneralPrefix(item) && (item.ranged || item.thrown);
 		}
 		//add to Terraria.Item.Prefix
 		internal static bool MagicPrefix(Item item)


### PR DESCRIPTION
### Description of the Change
As the title says, this change allows thrown weapons to have prefixes. This change only affects non-stacked thrown weapons as _GeneralPrefix(item)_ already checks for _item.maxStack_ being 1.
### Why this should be merged into tModLoader
This makes it more like how vanilla handles prefixes for weapons like the Bone Glove, which receives ranged prefixes. 
### Benefits
The fact that it allows prefixes on thrown weapons.
### Possible drawbacks
Mods that add these weapons would have to rebalance them to accommodate the potential for increased stats.
