### PR TITLE
skipselect now takes in player and world name

### DIFF
--- a/patches/tModLoader/Terraria.Initializers/LaunchInitializer.cs.patch
+++ b/patches/tModLoader/Terraria.Initializers/LaunchInitializer.cs.patch
@@ -41,12 +41,12 @@
 +
 +				if (skipSelectArgs != null)
 +				{
-+					Regex cmdRegEx = new Regex(@"(?<name>.+?):(?<val>.+)");
++					Regex cmdRegEx = new Regex(@"(?<name>.*?):(?<val>.*)");
 +					Match m = cmdRegEx.Match(skipSelectArgs);
 +					if (m.Success)
 +					{
-+						playerName = m.Groups[1].Value;
-+						worldName = m.Groups[2].Value;
++						playerName = m.Groups["name"].Value;
++						worldName = m.Groups["val"].Value;
 +					}
 +				}
 +

--- a/patches/tModLoader/Terraria.Initializers/LaunchInitializer.cs.patch
+++ b/patches/tModLoader/Terraria.Initializers/LaunchInitializer.cs.patch
@@ -1,5 +1,16 @@
 --- src/Terraria\Terraria.Initializers\LaunchInitializer.cs
 +++ src/tModLoader\Terraria.Initializers\LaunchInitializer.cs
+@@ -1,6 +_,9 @@
+-using System;
++using System.Collections.Generic;
+ using System.Diagnostics;
++using System.Linq;
++using System.Text.RegularExpressions;
+ using Terraria.Localization;
++using Terraria.ModLoader;
+ using Terraria.Social;
+ 
+ namespace Terraria.Initializers
 @@ -37,6 +_,14 @@
  			{
  				Netplay.ListenPort = listenPort;
@@ -15,21 +26,38 @@
  		}
  
  		private static void LoadClientParameters(Main game)
-@@ -66,6 +_,19 @@
+@@ -66,6 +_,36 @@
  				}))
  			{
  				game.AutoHost();
 +			}
++
 +			if (LaunchInitializer.HasParameter("-skipselect"))
 +			{
++				string skipSelectArgs = LaunchInitializer.TryParameter(new string[] { "-skipselect" });
++
++				string playerName = null;
++				string worldName = null;
++
++				if (skipSelectArgs != null)
++				{
++					Regex cmdRegEx = new Regex(@"(?<name>.+?):(?<val>.+)");
++					Match m = cmdRegEx.Match(skipSelectArgs);
++					if (m.Success)
++					{
++						playerName = m.Groups[1].Value;
++						worldName = m.Groups[2].Value;
++					}
++				}
++
 +				Main.showSplash = false;
 +				ModLoader.ModLoader.PostLoad += () =>
 +				{
 +					WorldGen.clearWorld();
 +					Main.LoadPlayers();
-+					Main.PlayerList[0].SetAsActive();
++					(Main.PlayerList.FirstOrDefault(x => x.Name == playerName) ?? Main.PlayerList[0]).SetAsActive();
 +					Main.LoadWorlds();
-+					Main.WorldList[0].SetAsActive();
++					(Main.WorldList.FirstOrDefault(x => x.Name == worldName) ?? Main.WorldList[0]).SetAsActive();
 +					WorldGen.playWorld();
 +				};
  			}


### PR DESCRIPTION
### Description of the Change

User will be able to specify which player and world they want to launch with -skipselect launch option. When either one of the fields is invalid/empty, it will choose the default player/world (meaning first in the list).

### Benefits

Adds the ability to specify which player/world is used for debugging.

### Sample Usage

`-skipselect "Itorius:TestWorld"`


