### PR TITLE
Recover GlobalItem data through unload

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.Default/MysteryGlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Default/MysteryGlobalItem.cs
@@ -32,7 +32,7 @@ namespace Terraria.ModLoader.Default
 
 		public override void Load(Item item, TagCompound tag)
 		{
-			ItemIO.LoadGlobals(item, tag.GetList<TagCompound>("list"));
+			ItemIO.LoadGlobals(item, tag.GetList<TagCompound>("modData"));
 		}
 	}
 }


### PR DESCRIPTION
### Description of the Change

GlobalItem data will no longer be lost when an Item is loaded without the GlobalItem's Mod active.
Judging by how simple this change is, it seems like a typo of sorts. I did several tests to make sure I am not overlooking something, but all GlobalItems seem to get recovered properly. Even after several reloads without the Mods activated, all GlobalItems were recovered.

### Alternate designs

I first considered extracting the contents of `MysteryGlobalItem.data` in `ItemIO.SaveGlobals(Item item)` and to append them directly to the TagCompound. I opted for this instead, because it is a much simpler change.

### Why this should be merged into tModLoader

It fixes part of a known issue.

### Applicable Issues

#265 


