### PR TITLE
Overlays no longer crash the game

### DIFF
--- a/patches/tModLoader/Terraria.Graphics.Effects/OverlayManager.cs.patch
+++ b/patches/tModLoader/Terraria.Graphics.Effects/OverlayManager.cs.patch
@@ -1,0 +1,28 @@
+--- src/Terraria\Terraria.Graphics.Effects\OverlayManager.cs
++++ src/tModLoader\Terraria.Graphics.Effects\OverlayManager.cs
+@@ -84,13 +_,13 @@
+ 			}
+ 		}
+ 
+-		public void Draw(SpriteBatch spriteBatch, RenderLayers layer)
++		public void Draw(SpriteBatch spriteBatch, RenderLayers layer, bool beginSpriteBatch = false)
+ 		{
+ 			if (this._overlayCount == 0)
+ 			{
+ 				return;
+ 			}
+-			bool flag = false;
++			bool flag = !beginSpriteBatch;
+ 			for (int i = 0; i < this._activeOverlays.Length; i++)
+ 			{
+ 				for (LinkedListNode<Overlay> linkedListNode = this._activeOverlays[i].First; linkedListNode != null; linkedListNode = linkedListNode.Next)
+@@ -107,7 +_,7 @@
+ 					}
+ 				}
+ 			}
+-			if (flag)
++			if (flag && beginSpriteBatch)
+ 			{
+ 				spriteBatch.End();
+ 			}
+

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4144,6 +4144,15 @@
  			bool flag = !Main.drawToScreen && Main.netMode != 2 && !Main.gameMenu && !Main.mapFullscreen && Lighting.NotRetro && Filters.Scene.CanCapture();
  			if (flag)
  			{
+@@ -57497,7 +_,7 @@
+ 			Main.spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, this.Rasterizer, null, Main.GameViewMatrix.TransformationMatrix);
+ 			this.DrawBackgroundBlackFill();
+ 			Main.spriteBatch.End();
+-			Overlays.Scene.Draw(Main.spriteBatch, RenderLayers.Landscape);
++			Overlays.Scene.Draw(Main.spriteBatch, RenderLayers.Landscape, true);
+ 			Main.spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, this.Rasterizer, null, Main.UIScaleMatrix);
+ 			if (Main.gameMenu || Main.netMode == 2)
+ 			{
 @@ -57717,6 +_,7 @@
  				IL_4196:
  				TimeLogger.DetailedDrawReset();
@@ -4152,6 +4161,15 @@
  				TimeLogger.DetailedDrawTime(35);
  				this.SortDrawCacheWorms();
  				this.DrawCachedProjs(this.DrawCacheProjsBehindProjectiles, true);
+@@ -57785,7 +_,7 @@
+ 				ScreenObstruction.Draw(Main.spriteBatch);
+ 				TimeLogger.DetailedDrawReset();
+ 				Main.spriteBatch.End();
+-				Overlays.Scene.Draw(Main.spriteBatch, RenderLayers.All);
++				Overlays.Scene.Draw(Main.spriteBatch, RenderLayers.All, true);
+ 				if (flag)
+ 				{
+ 					Filters.Scene.EndCapture();
 @@ -58021,6 +_,30 @@
  				else
  				{


### PR DESCRIPTION
### Description of the Change

`Overlays.Scene` is a vanilla feature that allows drawing overlays onto the screen at several points during the rendering process. Vanilla currently uses this to to draw the Sandstorm overlay and the Blizzard overlay.
However, as soon as you add an Overlay to `Overlays.Scene`, that uses `RenderLayers` other than `Landscape` or `All`, the game will crash. This happens because `OverlayManager.Draw(...)` calls `SpriteBatch.Begin(...)` even when End has not yet been called.
This change prevents that crash by only calling `SpriteBatch.Begin(...)` inside of `OverlayManager.Draw(...)` when the SpriteBatch is inactive at that point in the rendering process. It makes use of a default parameter to keep the codes changes as small as possible.

### Why this should be merged into tModLoader

This effectively allows one to draw arbitrary data after some distinct passes of the rendering process.
It is equivalent to several hooks into the draw process, but requires less code to implement. (Though it is less user-friendly than a few hooks)
It also fixes potential crashes in the vanilla code.

### Benefits

This can be used to draw things anywhere onto the screen after some passes of the drawing process. More precisely, it allows drawing directly after: (entries listed in the order they are drawn)
- Sky
- Landscape (The part of the background that is affected by parallax)
- Weather (Rain and clouds)
- Water Background (The blue layer drawn behind water to not make the landscape be visible through water)
- Cave Background
- Walls
- Tiles and NPCs
- All Entities (Players. Items, Dust, etc.)
- Water
- Screen Effects (Moon Lord Whiteout, Bloackout Debuf, etc.)

### Alternate designs

There is no alternate way to fix this crash, but the same capabilities could be achieved by adding several Hooks into the draw code. This would require more work, but would propably be easier to use.
If it is decided that this change will not be adapted, or if such hooks are desireable anyways, I would be happy to implement a draft of those draw hooks. Since I have wanted such hooks for a while now.

### Possible drawbacks

I can't think of any. This doesn't even add any significant code complexity to tML, since the capability is already part of vanilla. This just fixes a bug which currently makes that capability impossible to utilize.

### Sample Usage

Check out the [attachment](https://github.com/blushiemagic/tModLoader/files/1936051/Demonstration.zip) to see an example of how this can be used to draw an extra moon.
Note, that it is drawn behind the landscape, just like the vanilla moon, and is even visible in the Main menu.
Also note that the example code will crash the game without this patch.



