### PR TITLE
Ensure the world is fully loaded before updating entities

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -788,6 +788,14 @@
  				}
  				this._isDrawingOrUpdating = false;
  			}
+@@ -11968,6 +_,7 @@
+ 			}
+ 		}
+ 
++		internal static bool syncingWorld = false;
+ 		protected void DoUpdate(GameTime gameTime)
+ 		{
+ 			Main.ignoreErrors = true;
 @@ -11997,6 +_,7 @@
  			{
  				Main.InGameUI.Update(gameTime);
@@ -842,6 +850,15 @@
 +				PlayerHooks.SendClientChanges(Main.player[Main.myPlayer], Main.clientPlayer);
  			}
  			if (Main.netMode == 1)
+ 			{
+@@ -12624,6 +_,8 @@
+ 			PortalHelper.UpdatePortalPoints();
+ 			Main.tileSolid[379] = false;
+ 			Main.ActivePlayersCount = 0;
++			if (Main.syncingWorld)
++				goto IL_1B52;
+ 			int num12 = 0;
+ 			while (num12 < 255)
  			{
 @@ -12982,7 +_,7 @@
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -855,7 +855,7 @@
  			PortalHelper.UpdatePortalPoints();
  			Main.tileSolid[379] = false;
  			Main.ActivePlayersCount = 0;
-+			if (Main.syncingWorld)
++			if (Main.netMode == 1 && Main.syncingWorld)
 +				goto IL_1B52;
  			int num12 = 0;
  			while (num12 < 255)

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -788,14 +788,6 @@
  				}
  				this._isDrawingOrUpdating = false;
  			}
-@@ -11968,6 +_,7 @@
- 			}
- 		}
- 
-+		internal static bool syncingWorld = false;
- 		protected void DoUpdate(GameTime gameTime)
- 		{
- 			Main.ignoreErrors = true;
 @@ -11997,6 +_,7 @@
  			{
  				Main.InGameUI.Update(gameTime);
@@ -855,7 +847,7 @@
  			PortalHelper.UpdatePortalPoints();
  			Main.tileSolid[379] = false;
  			Main.ActivePlayersCount = 0;
-+			if (Main.netMode == 1 && Main.syncingWorld)
++			if (Main.netMode == 1 && Netplay.syncingWorld)
 +				goto IL_1B52;
  			int num12 = 0;
  			while (num12 < 255)

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -400,6 +400,14 @@
  						int num142 = this.reader.ReadInt32();
  						if (Main.netMode == 2 && num140 != this.whoAmI && !Main.pvpBuff[num141])
  						{
+@@ -2712,6 +_,7 @@
+ 					{
+ 						return;
+ 					}
++					Main.syncingWorld = false;
+ 					Main.anglerQuest = (int)this.reader.ReadByte();
+ 					Main.anglerQuestFinished = this.reader.ReadBoolean();
+ 					return;
 @@ -2838,7 +_,7 @@
  						}
  						int num176 = (int)this.reader.ReadInt16();

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -404,7 +404,7 @@
  					{
  						return;
  					}
-+					Main.syncingWorld = false;
++					Netplay.syncingWorld = false;
  					Main.anglerQuest = (int)this.reader.ReadByte();
  					Main.anglerQuestFinished = this.reader.ReadBoolean();
  					return;

--- a/patches/tModLoader/Terraria/Netplay.cs.patch
+++ b/patches/tModLoader/Terraria/Netplay.cs.patch
@@ -72,15 +72,21 @@
  			if (Netplay.portForwardOpen)
  			{
  				Netplay.mappings.Remove(Netplay.portForwardPort, "TCP");
-@@ -264,7 +_,7 @@
+@@ -264,9 +_,11 @@
  			}
  			Netplay.disconnect = false;
  			Netplay.Connection = new RemoteServer();
 -			Netplay.Connection.ReadBuffer = new byte[1024];
+-		}
+-
 +			Netplay.Connection.ReadBuffer = new byte[ushort.MaxValue];
- 		}
- 
++		}
++
++
++		internal static bool syncingWorld = false;
  		private static void InnerClientLoop()
+ 		{
+ 			try
 @@ -279,7 +_,7 @@
  					{
  						if (NetMessage.buffer[256].checkBytes)
@@ -94,7 +100,7 @@
  						{
  							Netplay.Connection.State = 6;
  							Main.player[Main.myPlayer].FindSpawn();
-+							Main.syncingWorld = true;
++							Netplay.syncingWorld = true;
  							NetMessage.SendData(8, -1, -1, null, Main.player[Main.myPlayer].SpawnX, (float)Main.player[Main.myPlayer].SpawnY, 0f, 0f, 0, 0, 0);
  						}
  						if (Netplay.Connection.State == 6 && num != Netplay.Connection.State)
@@ -110,7 +116,7 @@
  					}
  					num = Netplay.Connection.State;
  				}
-+				Main.syncingWorld = false;
++				Netplay.syncingWorld = false;
  				try
  				{
  					Netplay.Connection.Socket.Close();

--- a/patches/tModLoader/Terraria/Netplay.cs.patch
+++ b/patches/tModLoader/Terraria/Netplay.cs.patch
@@ -90,6 +90,14 @@
  						}
  						Netplay.Connection.IsActive = true;
  						if (Netplay.Connection.State == 0)
+@@ -332,6 +_,7 @@
+ 						{
+ 							Netplay.Connection.State = 6;
+ 							Main.player[Main.myPlayer].FindSpawn();
++							Main.syncingWorld = true;
+ 							NetMessage.SendData(8, -1, -1, null, Main.player[Main.myPlayer].SpawnX, (float)Main.player[Main.myPlayer].SpawnY, 0f, 0f, 0, 0, 0);
+ 						}
+ 						if (Netplay.Connection.State == 6 && num != Netplay.Connection.State)
 @@ -363,7 +_,6 @@
  									});
  							}
@@ -98,6 +106,14 @@
  					}
  					else if (Netplay.Connection.IsActive)
  					{
+@@ -372,6 +_,7 @@
+ 					}
+ 					num = Netplay.Connection.State;
+ 				}
++				Main.syncingWorld = false;
+ 				try
+ 				{
+ 					Netplay.Connection.Socket.Close();
 @@ -443,7 +_,7 @@
  			{
  				Netplay.Clients[num].Reset();


### PR DESCRIPTION
### Description of the Change

Before I go into detail on this change, [here's a video](https://youtu.be/YE0Qr5y36A8) to illustrate it more clearly.
When connecting to a server, vanilla will eventually send message 8 (`MessageID.RequestTileData`). This will prompt the server to send tile information, aswell as various game objects to the client. This includes all projectiles that are considered pets or have `netImportant` set to true (MessageBuffer:720). However, when connecting to a server, the pets/summons of other players will not show up unless they are re-summoned.
This has to do with the way the world is loaded on the client. While the data is being transmitted to the client, it will still perform regular updates. Because of this, summons, pets, and some other entities will get updated before their associated player is loaded (players are loaded last). Almost all entities that are in some way bound to a player will just deactivate themselves, when said player is not present; which is what's happening here.
My solution to this problem is to skip updating any entities while the client is initially receiving world data. In order to achieve this I added a condition to `Main.DoUpdate`, which will skip updating all entities if `Main.syncingWorld` is true.
`Main.syncingWorld` gets set before the client sends the request for world data (packet 8) to the server (Netplay:354). And it gets reset as soon as the client receives packet 74 (`MessageID.AnglerQuest`). I chose this packet to reset `Main.syncingWorld`, because it gets sent by the server, right after all players have been sent to the client. (MessageBuffer:789 and NetMessage:2270 which gets called by `MessageBuffer.SyncConnectedPlayer` -> `NetMessage.SendAnglerQuest`) If there are no other players, packet 74 will still get sent.
In case there is a connection issue, or if the client disconnects, `Main.syncingWorld` will also get reset (Netplay:393).

### Alternate designs

I considered adding an extra packet to tell the client when syncing is done, aswell as the possibilty of just re-sending the projectiles after all players have been synced. However, both of those options would require more code changes and cause more network overhead.

### Why this should be merged into tModLoader

It fixes an oversight in the vanilla code.

### Benefits

This will reduce the ammount of desyncing between clients.

### Possible drawbacks

There is a chance that a loss of connection at a specific point in the syncing process will leave the client permanently frozen, because `Main.syncingWorld` stays `true`. Though I tried to think of all possible outcomes of a connection loss while syncing, and I am farily certian that I covered all cases. My testing also never led to a frozen client.
