### PR TITLE
UpdateAutopause hook

### DIFF
--- a/ExampleMod/Items/Infinity.cs
+++ b/ExampleMod/Items/Infinity.cs
@@ -32,7 +32,7 @@ namespace ExampleMod.Items
 
 		public override Color? GetAlpha(Color lightColor)
 		{
-			return Color.White; // So the item's sprite isn't effected by light
+			return Color.White; // So the item's sprite isn't affected by light
 		}
 
         // This gives the item an outline that constantly changes color
@@ -50,6 +50,7 @@ namespace ExampleMod.Items
 			return true;
 		}
 
+		// Same as above but for drawing inside the player's inventory
 		public override bool PreDrawInInventory(SpriteBatch spriteBatch, Vector2 position, Rectangle frame, Color drawColor, Color itemColor, Vector2 origin, float scale)
 		{
 			Texture2D texture = Main.itemTexture[item.type];

--- a/ExampleMod/NPCs/ExampleChestSummon.cs
+++ b/ExampleMod/NPCs/ExampleChestSummon.cs
@@ -24,9 +24,15 @@ namespace ExampleMod.NPCs
 			}
 		}
 
+		// Allows mimic spawning in single player with autopause on
+		public override void UpdateAutopause()
+		{
+			LastChest = player.chest;
+		}
+
 		public static bool ChestItemSummonCheck(int x, int y, Mod mod)
 		{
-			if (Main.netMode == 1)
+			if (Main.netMode == 1 || !Main.hardMode)
 			{
 				return false;
 			}
@@ -73,7 +79,7 @@ namespace ExampleMod.NPCs
 					{
 						for (int k = y; k <= y + 1; k++)
 						{
-							if (Main.tile[j, k].type == 21)
+							if (TileID.Sets.BasicChest[Main.tile[j, k].type])
 							{
 								Main.tile[j, k].active(false);
 							}

--- a/patches/tModLoader/Terraria.ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModPlayer.cs
@@ -255,6 +255,14 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to modify the player's stats while the game is paused due to the autopause setting being on.
+		/// This is called in single player only, some time before the player's tick update would happen when the game isn't paused.
+		/// </summary>
+		public virtual void UpdateAutopause()
+		{
+		}
+
+		/// <summary>
 		/// This is called at the beginning of every tick update for this player, after checking whether the player exists.
 		/// </summary>
 		public virtual void PreUpdate()

--- a/patches/tModLoader/Terraria.ModLoader/PlayerHooks.cs
+++ b/patches/tModLoader/Terraria.ModLoader/PlayerHooks.cs
@@ -418,6 +418,16 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private static HookList HookUpdateAutopause = AddHook<Action>(p => p.UpdateAutopause);
+
+		public static void UpdateAutopause(Player player)
+		{
+			foreach (int index in HookUpdateAutopause.arr)
+			{
+				player.modPlayers[index].UpdateAutopause();
+			}
+		}
+
 		private static HookList HookPreUpdate = AddHook<Action>(p => p.PreUpdate);
 
 		public static void PreUpdate(Player player)

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -857,6 +857,14 @@
  			}
  			if (Main.netMode == 1)
  			{
+@@ -12612,6 +_,7 @@
+ 				{
+ 					Main.player[Main.myPlayer].AdjTiles();
+ 				}
++				PlayerHooks.UpdateAutopause(Main.player[Main.myPlayer]);
+ 				Main.gamePaused = true;
+ 				return;
+ 			}
 @@ -12624,6 +_,8 @@
  			PortalHelper.UpdatePortalPoints();
  			Main.tileSolid[379] = false;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3355,6 +3355,15 @@
  			while (Offset > 9)
  			{
  				Offset -= 10;
+@@ -23839,6 +_,8 @@
+ 			{
+ 				Main.tile[myX, myY] = new Tile();
+ 			}
++			if (!Main.tile[myX, myY].active())
++				return;
+ 			if (Main.tile[myX, myY].type == 21)
+ 			{
+ 				this.TileInteractionsMouseOver_Containers(myX, myY);
 @@ -23906,6 +_,7 @@
  					this.showItemIcon2 = -1;
  				}


### PR DESCRIPTION
### Description of the Change

* **Added**:

  * **ModPlayer UpdateAutopause hook**: allows doing things in single player when the game is paused due to the autopause option being on.
  * Usage example of the hook to Example Mod.

* **Changed**:

  * In Player.TileInteractionsCheckLongDistance, added a check if the tile is active.
  * ExampleMod ExampleChestSummon.ChestItemSummonCheck to match the vanilla mimic's checks.

### Why this should be merged into tModLoader

* Without the UpdateAutopause hook, some bugs related to the autopause option being on can't be fixed properly.
* Without the check in Player.TileInteractionsCheckLongDistance, tiles could show hover info even if they weren't active. In vanilla, this was really only noticeable when using chests to spawn mimics from keys.
* Without the change in ChestItemSummonCheck, spawning the NPC from a modded chest would remove the chest entity but leave the chest tiles instead of removing them too.

### Benefits

* **UpdateAutopause hook**: allows updating field values that would cause bugs with autopause the auto pause option being on, like mimic spawning from keys in chests.

### Sample Usage

See edit to ExampleChestSummon in the included ExampleMod edit.

### Notes

The lack of a check for the tile being active in Player.TileInteractionsCheckLongDistance is probably a vanilla bug rather than a tModLoader one.
