### PR TITLE
Collector's Edition Fix

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/PlayerHooks.cs
+++ b/patches/tModLoader/Terraria.ModLoader/PlayerHooks.cs
@@ -112,7 +112,7 @@ namespace Terraria.ModLoader
 
 		private static HookList HookSetupStartInventory = AddHook<Action<List<Item>>>(p => p.SetupStartInventory);
 
-		public static IList<Item> SetupStartInventory(Player player, bool newPlayer = true)
+		public static IList<Item> SetupStartInventory(Player player, bool mediumcoreDeath = false)
 		{
 			IList<Item> items = new List<Item>();
 			Item item = new Item();
@@ -127,7 +127,7 @@ namespace Terraria.ModLoader
 			item.SetDefaults(3506);
 			item.Prefix(-1);
 			items.Add(item);
-			if (Main.cEd && newPlayer)
+			if (Main.cEd && !mediumcoreDeath)
 			{
 				item = new Item();
 				item.SetDefaults(603);

--- a/patches/tModLoader/Terraria.ModLoader/PlayerHooks.cs
+++ b/patches/tModLoader/Terraria.ModLoader/PlayerHooks.cs
@@ -112,7 +112,7 @@ namespace Terraria.ModLoader
 
 		private static HookList HookSetupStartInventory = AddHook<Action<List<Item>>>(p => p.SetupStartInventory);
 
-		public static IList<Item> SetupStartInventory(Player player)
+		public static IList<Item> SetupStartInventory(Player player, bool newPlayer = true)
 		{
 			IList<Item> items = new List<Item>();
 			Item item = new Item();
@@ -127,6 +127,12 @@ namespace Terraria.ModLoader
 			item.SetDefaults(3506);
 			item.Prefix(-1);
 			items.Add(item);
+			if (Main.cEd && newPlayer)
+			{
+				item = new Item();
+				item.SetDefaults(603);
+				items.Add(item);
+			}
 			foreach (int index in HookSetupStartInventory.arr)
 			{
 				player.modPlayers[index].SetupStartInventory(items);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5229,7 +5229,7 @@
  
  		public void DropItems()
  		{
-+			IList<Item> startInventory = PlayerHooks.SetupStartInventory(this);
++			IList<Item> startInventory = PlayerHooks.SetupStartInventory(this, false);
 +			IDictionary<int, int> startCounts = new Dictionary<int, int>();
 +			foreach (Item item in startInventory)
 +			{
@@ -5563,7 +5563,7 @@
  			int[] array2 = new int[2];
  			this.hurtCooldowns = array2;
  			this.width = 20;
-@@ -39486,16 +_,17 @@
+@@ -39486,16 +_,13 @@
  			}
  			this.trashItem = new Item();
  			this.grappling[0] = -1;
@@ -5576,10 +5576,10 @@
 +			}
  			this.statManaMax = 20;
  			this.extraAccessory = false;
- 			if (Main.cEd)
- 			{
- 				this.inventory[3].SetDefaults(603, false);
- 			}
+-			if (Main.cEd)
+-			{
+-				this.inventory[3].SetDefaults(603, false);
+-			}
 -			for (int n = 0; n < 470; n++)
 +			for (int n = 0; n < this.adjTile.Length; n++)
  			{

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5229,7 +5229,7 @@
  
  		public void DropItems()
  		{
-+			IList<Item> startInventory = PlayerHooks.SetupStartInventory(this, false);
++			IList<Item> startInventory = PlayerHooks.SetupStartInventory(this, true);
 +			IDictionary<int, int> startCounts = new Dictionary<int, int>();
 +			foreach (Item item in startInventory)
 +			{


### PR DESCRIPTION
### Description of the Change

* Prevents the carrot from the Collector's Edition version of Terraria from replacing the item on the fourth slot on the hotbar on character creation after the SetupStartInventory hook is called.

### Applicable Issues

#347 

