### PR TITLE
Fixes mouse over hitbox for animated items

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -261,11 +261,10 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private static Rectangle AnimatedItemFrame(Item item)
+		internal static Rectangle ItemHoverHitbox(Item item)
 		{
-			int frameCount = Main.itemAnimations[item.type].FrameCount;
-			int frameDuration = Main.itemAnimations[item.type].TicksPerFrame;
-			return Main.itemAnimations[item.type].GetFrame(Main.itemTexture[item.type]);
+			Rectangle frame = Main.itemAnimations[item.type]?.GetFrame(Main.itemTexture[item.type]) ?? Main.itemTexture[item.type].Bounds;
+			return new Rectangle((int)(item.position.X + item.width * 0.5f - frame.Width * 0.5f), (int)(item.position.Y + item.height - frame.Height), frame.Width, frame.Height);
 		}
 
 		private static HookList HookChoosePrefix = AddHook<Func<Item, UnifiedRandom, int>>(g => g.ChoosePrefix);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3531,6 +3531,15 @@
  				Main.PlaySound(7, -1, -1, 1, 1f, 0f);
  			}
  		}
+@@ -37535,7 +_,7 @@
+ 				{
+ 					if (Main.item[i].active)
+ 					{
+-						Microsoft.Xna.Framework.Rectangle value = new Microsoft.Xna.Framework.Rectangle((int)((double)Main.item[i].position.X + (double)Main.item[i].width * 0.5 - (double)Main.itemTexture[Main.item[i].type].Width * 0.5), (int)(Main.item[i].position.Y + (float)Main.item[i].height - (float)Main.itemTexture[Main.item[i].type].Height), Main.itemTexture[Main.item[i].type].Width, Main.itemTexture[Main.item[i].type].Height);
++						Microsoft.Xna.Framework.Rectangle value = ItemLoader.ItemHoverHitbox(Main.item[i]);
+ 						if (rectangle.Intersects(value))
+ 						{
+ 							Main.player[Main.myPlayer].showItemIcon = false;
 @@ -37616,7 +_,7 @@
  						if (flag2 && ((Main.npc[k].type != 85 && Main.npc[k].type != 341 && Main.npc[k].aiStyle != 87) || Main.npc[k].ai[0] != 0f) && Main.npc[k].type != 488)
  						{


### PR DESCRIPTION
### Description of the Change

* Changes the hitbox that is used for showing the name of items in the world to be dependant on frame size than texture size. This fixes the bug where the name was being drawn when the cursor was far above the item.

* Replaced the unused ItemLoader.AnimatedItemFrame method with ItemLoader.ItemHoverHitbox method, which returns a rectangle representing the item texture's current frame for animated items, or the texture's dimensions for normal items, with its location set to the item's position.

### Applicable Issues

#349 