### PR TITLE
Fixes crash when loading unknown .xnb files

### DIFF
--- a/patches/tModLoader/Terraria.Localization.Content.de-DE.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.de-DE.tModLoader.json
@@ -69,7 +69,7 @@
 		// "LoadErrorSoundFailedToLoadAudioDeviceHint": "(Try making sure your computer has speakers attached and audio devices enabled)",
 		// "LoadErrorFontFailedToLoad": "The font file at {0} failed to load",
 		// "LoadErrorEffectFailedToLoad": "The effect file at {0} failed to load",
-		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {path}. Perhaps it should be in Fonts/ or Effects/",
+		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {0}. Perhaps it should be in Fonts/ or Effects/",
 		// "LoadErrorCannotLoadCompressedEffects": "Cannot load compressed effects.",
 		// "LoadErrorAddItemOnlyInLoad": "AddItem can only be called from Mod.Load or Mod.Autoload",
 		// "LoadError2ModItemSameName": "You tried to add 2 ModItems with the same name: {0}. Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddItem with 2 items of the same name.",

--- a/patches/tModLoader/Terraria.Localization.Content.en-US.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.en-US.tModLoader.json
@@ -69,7 +69,7 @@
 		"LoadErrorSoundFailedToLoadAudioDeviceHint": "(Try making sure your computer has speakers attached and audio devices enabled)",
 		"LoadErrorFontFailedToLoad": "The font file at {0} failed to load",
 		"LoadErrorEffectFailedToLoad": "The effect file at {0} failed to load",
-		"LoadErrorUnknownXNBFileHint": "Unknown xnb file {path}. Perhaps it should be in Fonts/ or Effects/",
+		"LoadErrorUnknownXNBFileHint": "Unknown xnb file {0}. Perhaps it should be in Fonts/ or Effects/",
 		"LoadErrorCannotLoadCompressedEffects": "Cannot load compressed effects.",
 		"LoadErrorAddItemOnlyInLoad": "AddItem can only be called from Mod.Load or Mod.Autoload",
 		"LoadError2ModItemSameName": "You tried to add 2 ModItems with the same name: {0}. Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddItem with 2 items of the same name.",

--- a/patches/tModLoader/Terraria.Localization.Content.es-ES.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.es-ES.tModLoader.json
@@ -69,7 +69,7 @@
 		// "LoadErrorSoundFailedToLoadAudioDeviceHint": "(Try making sure your computer has speakers attached and audio devices enabled)",
 		// "LoadErrorFontFailedToLoad": "The font file at {0} failed to load",
 		// "LoadErrorEffectFailedToLoad": "The effect file at {0} failed to load",
-		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {path}. Perhaps it should be in Fonts/ or Effects/",
+		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {0}. Perhaps it should be in Fonts/ or Effects/",
 		// "LoadErrorCannotLoadCompressedEffects": "Cannot load compressed effects.",
 		// "LoadErrorAddItemOnlyInLoad": "AddItem can only be called from Mod.Load or Mod.Autoload",
 		// "LoadError2ModItemSameName": "You tried to add 2 ModItems with the same name: {0}. Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddItem with 2 items of the same name.",

--- a/patches/tModLoader/Terraria.Localization.Content.fr-FR.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.fr-FR.tModLoader.json
@@ -69,7 +69,7 @@
 		// "LoadErrorSoundFailedToLoadAudioDeviceHint": "(Try making sure your computer has speakers attached and audio devices enabled)",
 		"LoadErrorFontFailedToLoad": "Le dossier de police situé en {0} n'a pas chargé correctement",
 		"LoadErrorEffectFailedToLoad": "Le dossier d'effets situé en {0} n'a pas chargé correctement",
-		"LoadErrorUnknownXNBFileHint": "Dossier xnb inconnu: {path}. Possiblement devrait être en Fonts/ ou Effects/",
+		"LoadErrorUnknownXNBFileHint": "Dossier xnb inconnu: {0}. Possiblement devrait être en Fonts/ ou Effects/",
 		"LoadErrorCannotLoadCompressedEffects": "Impossible de charger des effets compressés.",
 		"LoadErrorAddItemOnlyInLoad": "AddItem peut uniquement être appelé de Mod.Load ou Mod.Autoload",
 		"LoadError2ModItemSameName": "Vous avez essayé d'ajouter 2 ModItems avec le même nom: {0}. 2 classes possiblement partagent un même nom de classe mais dans des Espaces de Noms différents pendant l'autochargement ou vous avez manuellement appelé AddItem avec 2 objets possédant le même nom.",

--- a/patches/tModLoader/Terraria.Localization.Content.it-IT.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.it-IT.tModLoader.json
@@ -71,7 +71,7 @@
 		// "LoadErrorSoundFailedToLoadAudioDeviceHint": "(Try making sure your computer has speakers attached and audio devices enabled)",
 		// "LoadErrorFontFailedToLoad": "The font file at {0} failed to load",
 		// "LoadErrorEffectFailedToLoad": "The effect file at {0} failed to load",
-		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {path}. Perhaps it should be in Fonts/ or Effects/",
+		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {0}. Perhaps it should be in Fonts/ or Effects/",
 		// "LoadErrorCannotLoadCompressedEffects": "Cannot load compressed effects.",
 		// "LoadErrorAddItemOnlyInLoad": "AddItem can only be called from Mod.Load or Mod.Autoload",
 		// "LoadError2ModItemSameName": "You tried to add 2 ModItems with the same name: {0}. Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddItem with 2 items of the same name.",

--- a/patches/tModLoader/Terraria.Localization.Content.pl-PL.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.pl-PL.tModLoader.json
@@ -70,7 +70,7 @@
 		// "LoadErrorSoundFailedToLoadAudioDeviceHint": "(Try making sure your computer has speakers attached and audio devices enabled)",
 		// "LoadErrorFontFailedToLoad": "The font file at {0} failed to load",
 		// "LoadErrorEffectFailedToLoad": "The effect file at {0} failed to load",
-		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {path}. Perhaps it should be in Fonts/ or Effects/",
+		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {0}. Perhaps it should be in Fonts/ or Effects/",
 		// "LoadErrorCannotLoadCompressedEffects": "Cannot load compressed effects.",
 		// "LoadErrorAddItemOnlyInLoad": "AddItem can only be called from Mod.Load or Mod.Autoload",
 		// "LoadError2ModItemSameName": "You tried to add 2 ModItems with the same name: {0}. Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddItem with 2 items of the same name.",

--- a/patches/tModLoader/Terraria.Localization.Content.pt-BR.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.pt-BR.tModLoader.json
@@ -69,7 +69,7 @@
 		// "LoadErrorSoundFailedToLoadAudioDeviceHint": "(Try making sure your computer has speakers attached and audio devices enabled)",
 		// "LoadErrorFontFailedToLoad": "The font file at {0} failed to load",
 		// "LoadErrorEffectFailedToLoad": "The effect file at {0} failed to load",
-		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {path}. Perhaps it should be in Fonts/ or Effects/",
+		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {0}. Perhaps it should be in Fonts/ or Effects/",
 		// "LoadErrorCannotLoadCompressedEffects": "Cannot load compressed effects.",
 		// "LoadErrorAddItemOnlyInLoad": "AddItem can only be called from Mod.Load or Mod.Autoload",
 		// "LoadError2ModItemSameName": "You tried to add 2 ModItems with the same name: {0}. Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddItem with 2 items of the same name.",

--- a/patches/tModLoader/Terraria.Localization.Content.ru-RU.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content.ru-RU.tModLoader.json
@@ -69,7 +69,7 @@
 		// "LoadErrorSoundFailedToLoadAudioDeviceHint": "(Try making sure your computer has speakers attached and audio devices enabled)",
 		// "LoadErrorFontFailedToLoad": "The font file at {0} failed to load",
 		// "LoadErrorEffectFailedToLoad": "The effect file at {0} failed to load",
-		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {path}. Perhaps it should be in Fonts/ or Effects/",
+		// "LoadErrorUnknownXNBFileHint": "Unknown xnb file {0}. Perhaps it should be in Fonts/ or Effects/",
 		// "LoadErrorCannotLoadCompressedEffects": "Cannot load compressed effects.",
 		// "LoadErrorAddItemOnlyInLoad": "AddItem can only be called from Mod.Load or Mod.Autoload",
 		// "LoadError2ModItemSameName": "You tried to add 2 ModItems with the same name: {0}. Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddItem with 2 items of the same name.",


### PR DESCRIPTION
### Description of the Change

Changed tModLoader localization line **LoadErrorUnknownXNBFileHint** to use `{0}` instead of `{path}`.


### Why this should be merged into tModLoader

Currently, having an unknown XNB file will cause the following error:
```
Silently Caught Exception: Input string was not in a correct format.   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)   at Terraria.ModLoader.ModCompile.<>c.<ActivateExceptionReporting>b__15_0(Object sender, FirstChanceExceptionEventArgs exceptionArgs)
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at Terraria.Localization.LanguageManager.GetTextValue(String key, Object arg0)
   at Terraria.ModLoader.Mod.LoadResourceFromStream(String path, Int32 len, BinaryReader reader)
   at Terraria.ModLoader.IO.TmodFile.Read(LoadedState desiredState, ReadStreamingAsset streamingHandler)
   at Terraria.ModLoader.ModLoader.do_Load(Object threadContext)
   at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()
```
This error is caused by [this line](https://github.com/blushiemagic/tModLoader/blob/486e5800b70324fd91a559d74902de71217df2a7/patches/tModLoader/Terraria.ModLoader/Mod.cs#L172) in Mod.cs, because the corresponding line in the localization has an invalid `{path}` tag where a `{0}` tag should be.
