### PR TITLE
Create Slime.cs

### DIFF
--- a/ExampleMod/NPCs/Slime.cs
+++ b/ExampleMod/NPCs/Slime.cs
@@ -1,0 +1,33 @@
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ModLoader;
+using Terraria.ID;
+using System.IO;
+
+namespace ExampleMod.NPCs
+{
+	class AquaSlime : ModNPC
+	{
+		public override string Texture { get { return "Terraria/NPC_" + NPCID.BlueSlime; } }
+
+		public override void SetStaticDefaults()
+		{
+			DisplayName.SetDefault("Aqua Slime");
+			Main.npcFrameCount[npc.type] = Main.npcFrameCount[NPCID.BlueSlime];
+		}
+		
+		public override void SetDefaults()
+		{
+			npc.CloneDefaults(NPCID.BlueSlime);
+			npc.aiStyle = 1;
+			npc.color = Color.Aqua;
+			animationType = NPCID.BlueSlime;
+		}
+		// Demonstrates loading custom bools from ExampleMod.cs for use with NPC Spawning
+		public override float SpawnChance(NPCSpawnInfo spawnInfo)
+		{
+			return ExampleMod.NoBiomeNormalSpawn(spawnInfo) ? SpawnCondition.OverworldDaySlime.Chance * 0.5f : 0f;
+		}
+
+	}
+}


### PR DESCRIPTION
Essentially, this file would showcase how to use a bool created in ExampleMod.cs to spawn in a custom Slime enemy.

### Description of the Change

Essentially, this provides an example of using a custom global bool to spawn a basic NPC.

### Alternate designs

Any type of NPC could have been considered for this particular file, but Slimes are probably the easiest type to demonstrate the effect of the example, as they can spawn pretty much anywhere..

### Why this should be merged into tModLoader

This would show those whom are new to tModLoader modding, such as myself, how to utilize the example bools in the main .cs file.

### Benefits

As previously stated, new modders would be able to learn a little trick to shorten code repetition in their mods.

### Possible drawbacks

There will be a new NPC that spawns in worlds while ExampleMod is active.

### Applicable Issues

ModNPC spawning using bool created in master mod file.

### Sample Usage

public override float SpawnChance(NPCSpawnInfo spawnInfo)
{
	return ExampleMod.NoBiomeNormalSpawn(spawnInfo) ? SpawnCondition.OverworldDaySlime.Chance * 0.5f : 0f;
}

