### PR TITLE
WIP: Adding Alt Ore Functionality

### DIFF
--- a/patches/tModLoader/Terraria.GameContent.Biomes/MiningExplosivesBiome.cs.patch
+++ b/patches/tModLoader/Terraria.GameContent.Biomes/MiningExplosivesBiome.cs.patch
@@ -1,0 +1,26 @@
+--- src/Terraria\Terraria.GameContent.Biomes\MiningExplosivesBiome.cs
++++ src/tModLoader\Terraria.GameContent.Biomes\MiningExplosivesBiome.cs
+@@ -1,6 +_,7 @@
+ using Microsoft.Xna.Framework;
+ using System;
+ using Terraria.GameContent.Generation;
++using Terraria.ModLoader;
+ using Terraria.World.Generation;
+ 
+ namespace Terraria.GameContent.Biomes
+@@ -15,10 +_,10 @@
+ 			}
+ 			ushort type = Utils.SelectRandom<ushort>(GenBase._random, new ushort[]
+ 				{
+-					(WorldGen.goldBar == 19) ? (ushort)8 : (ushort)169,
+-					(WorldGen.silverBar == 21) ? (ushort)9 : (ushort)168,
+-					(WorldGen.ironBar == 22) ? (ushort)6 : (ushort)167,
+-					(WorldGen.copperBar == 20) ? (ushort)7 : (ushort)166
++					WorldGen.GoldTierOre,
++					WorldGen.SilverTierOre,
++					WorldGen.IronTierOre,
++					WorldGen.CopperTierOre
+ 				});
+ 			double num = GenBase._random.NextDouble() * 2.0 - 1.0;
+ 			if (!WorldUtils.Find(origin, Searches.Chain((num > 0.0) ? (GenSearch)new Searches.Right(40) : (GenSearch)new Searches.Left(40), new GenCondition[]
+

--- a/patches/tModLoader/Terraria.ModLoader/AltAdamantite.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltAdamantite.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using Terraria.ID;
+
+namespace Terraria.ModLoader
+{
+	public class AltAdamantite
+	{
+		public readonly int oreTileType;
+		public readonly string oreBlessingText;
+		public readonly float abundanceMultiplier;
+		private static readonly List<AltAdamantite> AltAdamantites = new List<AltAdamantite>();
+		internal static bool vanillaAltsAdded = false;
+		public static AltAdamantite ChosenAltAdamantite { get; private set; }
+
+		public AltAdamantite(int oreTileType, string oreBlessingText, float abundanceMultiplier = 1f)
+		{
+			this.oreTileType = TileLoader.TileCount > oreTileType ? oreTileType : throw new Exception("oreTileType is an invalid tile");
+			this.oreBlessingText = oreBlessingText;
+			this.abundanceMultiplier = abundanceMultiplier;
+		}
+
+		public static AltAdamantite GetAltAdamantite()
+		{
+			if (!vanillaAltsAdded)
+			{
+				WorldGen.AddAlt(new AltCobalt(TileID.Adamantite, Lang.misc[14].Value));
+				WorldGen.AddAlt(new AltCobalt(TileID.Titanium, Lang.misc[23].Value, 0.9f));
+			}
+			return ChosenAltAdamantite ?? (ChosenAltAdamantite = AltAdamantites[WorldGen.genRand.Next(AltAdamantites.Count)]);
+		}
+
+		internal static void UnchooseAltAdamantite()
+		{
+			ChosenAltAdamantite = null;
+		}
+
+		internal static void Add(AltAdamantite alt)
+		{
+			AltAdamantites.Add(alt);
+		}
+
+		internal static bool unchosen()
+		{
+			return ChosenAltAdamantite == null;
+		}
+
+		internal static void tryFind(int oreTileType)
+		{
+			foreach (var altAdamantite in AltAdamantites)
+			{
+				if (altAdamantite.oreTileType != oreTileType) continue;
+				ChosenAltAdamantite = altAdamantite;
+				break;
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria.ModLoader/AltCobalt.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltCobalt.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using Terraria.ID;
+
+namespace Terraria.ModLoader
+{
+	public class AltCobalt
+	{
+		public readonly int oreTileType;
+		public readonly string oreBlessingText;
+		public readonly float abundanceMultiplier;
+		private static readonly List<AltCobalt> AltCobalts = new List<AltCobalt>();
+		internal static bool vanillaAltsAdded = false;
+		public static AltCobalt ChosenAltCobalt { get; private set; }
+
+		public AltCobalt(int oreTileType, string oreBlessingText, float abundanceMultiplier = 1f)
+		{
+			this.oreTileType = TileLoader.TileCount > oreTileType ? oreTileType : throw new Exception("oreTileType is an invalid tile");
+			this.oreBlessingText = oreBlessingText;
+			this.abundanceMultiplier = abundanceMultiplier;
+		}
+
+		public static AltCobalt GetAltCobalt()
+		{
+			if (!vanillaAltsAdded)
+			{
+				WorldGen.AddAlt(new AltCobalt(TileID.Cobalt, Lang.misc[12].Value));
+				WorldGen.AddAlt(new AltCobalt(TileID.Palladium, Lang.misc[21].Value, 0.9f));
+			}
+			return ChosenAltCobalt ?? (ChosenAltCobalt = AltCobalts[WorldGen.genRand.Next(AltCobalts.Count)]);
+		}
+
+		internal static void UnchooseAltCobalt()
+		{
+			ChosenAltCobalt = null;
+		}
+
+		internal static void Add(AltCobalt alt)
+		{
+			AltCobalts.Add(alt);
+		}
+
+		internal static bool unchosen()
+		{
+			return ChosenAltCobalt == null;
+		}
+
+		internal static void tryFind(int oreTileType)
+		{
+			foreach (var altCobalt in AltCobalts)
+			{
+				if (altCobalt.oreTileType != oreTileType) continue;
+				ChosenAltCobalt = altCobalt;
+				break;
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria.ModLoader/AltCopper.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltCopper.cs
@@ -17,7 +17,7 @@ namespace Terraria.ModLoader
 			this.oreBarItemType = ItemLoader.ItemCount > oreBarItemType ? oreBarItemType : throw new Exception("oreBarItemType is an invalid item");
 		}
 
-		internal static AltCopper GetAltCopper()
+		public static AltCopper GetAltCopper()
 		{
 			return ChosenAltCopper ?? (ChosenAltCopper = AltCoppers[WorldGen.genRand.Next(AltCoppers.Count)]);
 		}

--- a/patches/tModLoader/Terraria.ModLoader/AltCopper.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltCopper.cs
@@ -9,7 +9,7 @@ namespace Terraria.ModLoader
 		public readonly int oreBarItemType;
 		private static readonly List<AltCopper> AltCoppers = new List<AltCopper>();
 
-		public static AltCopper ChosenAltCopper;
+		public static AltCopper ChosenAltCopper { get; private set; }
 
 		public AltCopper(int oreTileType, int oreBarItemType)
 		{
@@ -20,6 +20,11 @@ namespace Terraria.ModLoader
 		internal static AltCopper GetAltCopper()
 		{
 			return ChosenAltCopper ?? (ChosenAltCopper = AltCoppers[WorldGen.genRand.Next(AltCoppers.Count)]);
+		}
+
+		internal static void UnchooseAltCopper()
+		{
+			ChosenAltCopper = null;
 		}
 
 		internal static void Add(AltCopper alt)

--- a/patches/tModLoader/Terraria.ModLoader/AltCopper.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltCopper.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Terraria.ModLoader
+{
+	public class AltCopper
+	{
+		public readonly int oreTileType;
+		public readonly int oreBarItemType;
+		private static readonly List<AltCopper> AltCoppers = new List<AltCopper>();
+
+		public static AltCopper ChosenAltCopper;
+
+		public AltCopper(int oreTileType, int oreBarItemType)
+		{
+			this.oreTileType = TileLoader.TileCount > oreTileType ? oreTileType : throw new Exception("oreTileType is an invalid tile");
+			this.oreBarItemType = ItemLoader.ItemCount > oreBarItemType ? oreBarItemType : throw new Exception("oreBarItemType is an invalid item");
+		}
+
+		internal static AltCopper GetAltCopper()
+		{
+			return ChosenAltCopper ?? (ChosenAltCopper = AltCoppers[WorldGen.genRand.Next(AltCoppers.Count)]);
+		}
+
+		internal static void Add(AltCopper alt)
+		{
+			AltCoppers.Add(alt);
+		}
+	}
+}

--- a/patches/tModLoader/Terraria.ModLoader/AltGold.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltGold.cs
@@ -9,7 +9,7 @@ namespace Terraria.ModLoader
 		public readonly int oreBarItemType;
 		private static readonly List<AltGold> AltGolds = new List<AltGold>();
 
-		public static AltGold ChosenAltGold;
+		public static AltGold ChosenAltGold { get; private set; }
 
 		public AltGold(int oreTileType, int oreBarItemType)
 		{
@@ -20,6 +20,11 @@ namespace Terraria.ModLoader
 		internal static AltGold GetAltGold()
 		{
 			return ChosenAltGold ?? (ChosenAltGold = AltGolds[WorldGen.genRand.Next(AltGolds.Count)]);
+		}
+
+		internal static void UnchooseAltGold()
+		{
+			ChosenAltGold = null;
 		}
 
 		internal static void Add(AltGold alt)

--- a/patches/tModLoader/Terraria.ModLoader/AltGold.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltGold.cs
@@ -17,7 +17,7 @@ namespace Terraria.ModLoader
 			this.oreBarItemType = ItemLoader.ItemCount > oreBarItemType ? oreBarItemType : throw new Exception("oreBarItemType is an invalid item");
 		}
 
-		internal static AltGold GetAltGold()
+		public static AltGold GetAltGold()
 		{
 			return ChosenAltGold ?? (ChosenAltGold = AltGolds[WorldGen.genRand.Next(AltGolds.Count)]);
 		}

--- a/patches/tModLoader/Terraria.ModLoader/AltGold.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltGold.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Terraria.ModLoader
+{
+	public class AltGold
+	{
+		public readonly int oreTileType;
+		public readonly int oreBarItemType;
+		private static readonly List<AltGold> AltGolds = new List<AltGold>();
+
+		public static AltGold ChosenAltGold;
+
+		public AltGold(int oreTileType, int oreBarItemType)
+		{
+			this.oreTileType = TileLoader.TileCount > oreTileType ? oreTileType : throw new Exception("oreTileType is an invalid tile");
+			this.oreBarItemType = ItemLoader.ItemCount > oreBarItemType ? oreBarItemType : throw new Exception("oreBarItemType is an invalid item");
+		}
+
+		internal static AltGold GetAltGold()
+		{
+			return ChosenAltGold ?? (ChosenAltGold = AltGolds[WorldGen.genRand.Next(AltGolds.Count)]);
+		}
+
+		internal static void Add(AltGold alt)
+		{
+			AltGolds.Add(alt);
+		}
+	}
+}

--- a/patches/tModLoader/Terraria.ModLoader/AltIron.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltIron.cs
@@ -17,7 +17,7 @@ namespace Terraria.ModLoader
 			this.oreBarItemType = ItemLoader.ItemCount > oreBarItemType ? oreBarItemType : throw new Exception("oreBarItemType is an invalid item");
 		}
 
-		internal static AltIron GetAltIron()
+		public static AltIron GetAltIron()
 		{
 			return ChosenAltIron ?? (ChosenAltIron = AltIrons[WorldGen.genRand.Next(AltIrons.Count)]);
 		}

--- a/patches/tModLoader/Terraria.ModLoader/AltIron.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltIron.cs
@@ -9,7 +9,7 @@ namespace Terraria.ModLoader
 		public readonly int oreBarItemType;
 		private static readonly List<AltIron> AltIrons = new List<AltIron>();
 
-		public static AltIron ChosenAltIron;
+		public static AltIron ChosenAltIron { get; private set; }
 
 		public AltIron(int oreTileType, int oreBarItemType)
 		{
@@ -20,6 +20,11 @@ namespace Terraria.ModLoader
 		internal static AltIron GetAltIron()
 		{
 			return ChosenAltIron ?? (ChosenAltIron = AltIrons[WorldGen.genRand.Next(AltIrons.Count)]);
+		}
+
+		internal static void UnchooseAltIron()
+		{
+			ChosenAltIron = null;
 		}
 
 		internal static void Add(AltIron alt)

--- a/patches/tModLoader/Terraria.ModLoader/AltIron.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltIron.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Terraria.ModLoader
+{
+	public class AltIron
+	{
+		public readonly int oreTileType;
+		public readonly int oreBarItemType;
+		private static readonly List<AltIron> AltIrons = new List<AltIron>();
+
+		public static AltIron ChosenAltIron;
+
+		public AltIron(int oreTileType, int oreBarItemType)
+		{
+			this.oreTileType = TileLoader.TileCount > oreTileType ? oreTileType : throw new Exception("oreTileType is an invalid tile");
+			this.oreBarItemType = ItemLoader.ItemCount > oreBarItemType ? oreBarItemType : throw new Exception("oreBarItemType is an invalid item");
+		}
+
+		internal static AltIron GetAltIron()
+		{
+			return ChosenAltIron ?? (ChosenAltIron = AltIrons[WorldGen.genRand.Next(AltIrons.Count)]);
+		}
+
+		internal static void Add(AltIron alt)
+		{
+			AltIrons.Add(alt);
+		}
+	}
+}

--- a/patches/tModLoader/Terraria.ModLoader/AltMythril.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltMythril.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using Terraria.ID;
+
+namespace Terraria.ModLoader
+{
+	public class AltMythril
+	{
+		public readonly int oreTileType;
+		public readonly string oreBlessingText;
+		public readonly float abundanceMultiplier;
+		private static readonly List<AltMythril> AltMythrils = new List<AltMythril>();
+		internal static bool vanillaAltsAdded = false;
+		public static AltMythril ChosenAltMythril { get; private set; }
+
+		public AltMythril(int oreTileType, string oreBlessingText, float abundanceMultiplier = 1f)
+		{
+			this.oreTileType = TileLoader.TileCount > oreTileType ? oreTileType : throw new Exception("oreTileType is an invalid tile");
+			this.oreBlessingText = oreBlessingText;
+			this.abundanceMultiplier = abundanceMultiplier;
+		}
+
+		public static AltMythril GetAltMythril()
+		{
+			if (!vanillaAltsAdded)
+			{
+				WorldGen.AddAlt(new AltCobalt(TileID.Mythril, Lang.misc[13].Value));
+				WorldGen.AddAlt(new AltCobalt(TileID.Orichalcum, Lang.misc[22].Value, 0.9f));
+			}
+			return ChosenAltMythril ?? (ChosenAltMythril = AltMythrils[WorldGen.genRand.Next(AltMythrils.Count)]);
+		}
+
+		internal static void UnchooseAltMythril()
+		{
+			ChosenAltMythril = null;
+		}
+
+		internal static void Add(AltMythril alt)
+		{
+			AltMythrils.Add(alt);
+		}
+
+		internal static bool unchosen()
+		{
+			return ChosenAltMythril == null;
+		}
+
+		internal static void tryFind(int oreTileType)
+		{
+			foreach (var altMythril in AltMythrils)
+			{
+				if (altMythril.oreTileType != oreTileType) continue;
+				ChosenAltMythril = altMythril;
+				break;
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria.ModLoader/AltSilver.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltSilver.cs
@@ -9,7 +9,7 @@ namespace Terraria.ModLoader
 		public readonly int oreBarItemType;
 		private static readonly List<AltSilver> AltSilvers = new List<AltSilver>();
 
-		public static AltSilver ChosenAltSilver;
+		public static AltSilver ChosenAltSilver { get; private set; }
 
 		public AltSilver(int oreTileType, int oreBarItemType)
 		{
@@ -17,9 +17,14 @@ namespace Terraria.ModLoader
 			this.oreBarItemType = ItemLoader.ItemCount > oreBarItemType ? oreBarItemType : throw new Exception("oreBarItemType is an invalid item");
 		}
 
-		internal static AltSilver GetAltSilver()
+		public static AltSilver GetAltSilver()
 		{
 			return ChosenAltSilver ?? (ChosenAltSilver = AltSilvers[WorldGen.genRand.Next(AltSilvers.Count)]);
+		}
+
+		internal static void UnchooseAltSilver()
+		{
+			ChosenAltSilver = null;
 		}
 
 		internal static void Add(AltSilver alt)

--- a/patches/tModLoader/Terraria.ModLoader/AltSilver.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AltSilver.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Terraria.ModLoader
+{
+	public class AltSilver
+	{
+		public readonly int oreTileType;
+		public readonly int oreBarItemType;
+		private static readonly List<AltSilver> AltSilvers = new List<AltSilver>();
+
+		public static AltSilver ChosenAltSilver;
+
+		public AltSilver(int oreTileType, int oreBarItemType)
+		{
+			this.oreTileType = TileLoader.TileCount > oreTileType ? oreTileType : throw new Exception("oreTileType is an invalid tile");
+			this.oreBarItemType = ItemLoader.ItemCount > oreBarItemType ? oreBarItemType : throw new Exception("oreBarItemType is an invalid item");
+		}
+
+		internal static AltSilver GetAltSilver()
+		{
+			return ChosenAltSilver ?? (ChosenAltSilver = AltSilvers[WorldGen.genRand.Next(AltSilvers.Count)]);
+		}
+
+		internal static void Add(AltSilver alt)
+		{
+			AltSilvers.Add(alt);
+		}
+	}
+}

--- a/patches/tModLoader/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria.csproj.patch
@@ -131,7 +131,7 @@
      <Compile Include="Terraria.ID\NPCID.cs" />
      <Compile Include="Terraria.ID\PlayerTextureID.cs" />
      <Compile Include="Terraria.ID\PlayerVariantID.cs" />
-@@ -368,6 +_,167 @@
+@@ -368,6 +_,171 @@
      <Compile Include="Terraria.Map\MapHelper.cs" />
      <Compile Include="Terraria.Map\MapTile.cs" />
      <Compile Include="Terraria.Map\WorldMap.cs" />
@@ -211,6 +211,10 @@
 +    <Compile Include="Terraria.ModLoader.UI\UIModSources.cs" />
 +    <Compile Include="Terraria.ModLoader.UI\UIUpdateMessage.cs" />
 +    <Compile Include="Terraria.ModLoader.UI\UIUploadMod.cs" />
++    <Compile Include="Terraria.ModLoader\AltCopper.cs" />
++    <Compile Include="Terraria.ModLoader\AltGold.cs" />
++    <Compile Include="Terraria.ModLoader\AltIron.cs" />
++    <Compile Include="Terraria.ModLoader\AltSilver.cs" />
 +    <Compile Include="Terraria.ModLoader\AssemblyManager.cs" />
 +    <Compile Include="Terraria.ModLoader\AutoloadEquip.cs" />
 +    <Compile Include="Terraria.ModLoader\AutoloadHead.cs" />

--- a/patches/tModLoader/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria.csproj.patch
@@ -131,7 +131,7 @@
      <Compile Include="Terraria.ID\NPCID.cs" />
      <Compile Include="Terraria.ID\PlayerTextureID.cs" />
      <Compile Include="Terraria.ID\PlayerVariantID.cs" />
-@@ -368,6 +_,171 @@
+@@ -368,6 +_,174 @@
      <Compile Include="Terraria.Map\MapHelper.cs" />
      <Compile Include="Terraria.Map\MapTile.cs" />
      <Compile Include="Terraria.Map\WorldMap.cs" />
@@ -211,9 +211,12 @@
 +    <Compile Include="Terraria.ModLoader.UI\UIModSources.cs" />
 +    <Compile Include="Terraria.ModLoader.UI\UIUpdateMessage.cs" />
 +    <Compile Include="Terraria.ModLoader.UI\UIUploadMod.cs" />
++    <Compile Include="Terraria.ModLoader\AltAdamantite.cs" />
++    <Compile Include="Terraria.ModLoader\AltCobalt.cs" />
 +    <Compile Include="Terraria.ModLoader\AltCopper.cs" />
 +    <Compile Include="Terraria.ModLoader\AltGold.cs" />
 +    <Compile Include="Terraria.ModLoader\AltIron.cs" />
++    <Compile Include="Terraria.ModLoader\AltMythril.cs" />
 +    <Compile Include="Terraria.ModLoader\AltSilver.cs" />
 +    <Compile Include="Terraria.ModLoader\AssemblyManager.cs" />
 +    <Compile Include="Terraria.ModLoader\AutoloadEquip.cs" />

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -168,7 +168,7 @@
  			WorldGen.worldCleared = true;
  		}
  
-@@ -4566,17 +_,18 @@
+@@ -4566,21 +_,32 @@
  
  		public static void generateWorld(int seed, GenerationProgress customProgressObject = null)
  		{
@@ -193,6 +193,20 @@
  			int copper = 7;
  			int iron = 6;
  			int silver = 9;
+ 			int gold = 8;
++			
++			WorldGen.AddAlt(new AltCopper(TileID.Copper, ItemID.CopperBar));
++			WorldGen.AddAlt(new AltCopper(TileID.Tin, ItemID.TinBar));
++			WorldGen.AddAlt(new AltIron(TileID.Iron, ItemID.IronBar));
++			WorldGen.AddAlt(new AltIron(TileID.Lead, ItemID.LeadBar));
++			WorldGen.AddAlt(new AltSilver(TileID.Silver, ItemID.SilverBar));
++			WorldGen.AddAlt(new AltSilver(TileID.Tungsten, ItemID.TungstenBar));
++			WorldGen.AddAlt(new AltGold(TileID.Gold, ItemID.GoldBar));
++			WorldGen.AddAlt(new AltGold(TileID.Platinum, ItemID.PlatinumBar));
++			
+ 			int dungeonSide = 0;
+ 			ushort jungleHut = (ushort)WorldGen.genRand.Next(5);
+ 			int howFar = 0;
 @@ -4617,6 +_,7 @@
  					}
  				}
@@ -201,6 +215,57 @@
  			WorldGen.AddGenerationPass("Reset", delegate(GenerationProgress progress)
  				{
  					Liquid.ReInit();
+@@ -4637,38 +_,18 @@
+ 					int num = 86400;
+ 					Main.slimeRainTime = (double)(-(double)WorldGen.genRand.Next(num * 2, num * 3));
+ 					Main.cloudBGActive = (float)(-(float)WorldGen.genRand.Next(8640, 86400));
+-					WorldGen.CopperTierOre = 7;
+-					WorldGen.IronTierOre = 6;
+-					WorldGen.SilverTierOre = 9;
+-					WorldGen.GoldTierOre = 8;
+-					WorldGen.copperBar = 20;
+-					WorldGen.ironBar = 22;
+-					WorldGen.silverBar = 21;
+-					WorldGen.goldBar = 19;
+-					if (WorldGen.genRand.Next(2) == 0)
+-					{
+-						copper = 166;
+-						WorldGen.copperBar = 703;
+-						WorldGen.CopperTierOre = 166;
+-					}
+-					if (WorldGen.genRand.Next(2) == 0)
+-					{
+-						iron = 167;
+-						WorldGen.ironBar = 704;
+-						WorldGen.IronTierOre = 167;
+-					}
+-					if (WorldGen.genRand.Next(2) == 0)
+-					{
+-						silver = 168;
+-						WorldGen.silverBar = 705;
+-						WorldGen.SilverTierOre = 168;
+-					}
+-					if (WorldGen.genRand.Next(2) == 0)
+-					{
+-						gold = 169;
+-						WorldGen.goldBar = 706;
+-						WorldGen.GoldTierOre = 169;
+-					}
++					copper = AltCopper.GetAltCopper().oreTileType;
++					iron = AltIron.GetAltIron().oreTileType
++					silver = AltSilver.GetAltSilver().oreTileType
++					gold = AltGold.GetAltGold().oreTileType
++					WorldGen.CopperTierOre = AltCopper.GetAltCopper().oreTileType;
++					WorldGen.IronTierOre = AltIron.GetAltIron().oreTileType;
++					WorldGen.SilverTierOre = AltSilver.GetAltSilver().oreTileType;
++					WorldGen.GoldTierOre = AltGold.GetAltGold().oreTileType;
++					WorldGen.copperBar = AltCopper.GetAltCopper().oreBarItemType;
++					WorldGen.ironBar = AltIron.GetAltIron().oreBarItemType;
++					WorldGen.silverBar = AltSilver.GetAltSilver().oreBarItemType;
++					WorldGen.goldBar = AltGold.GetAltGold().oreBarItemType;
+ 					WorldGen.crimson = (WorldGen.genRand.Next(2) == 0);
+ 					if (WorldGen.WorldGenParam_Evil == 0)
+ 					{
 @@ -7468,7 +_,7 @@
  									int num12 = WorldGen.genRand.Next(num - m, num + m + 1);
  									int num13 = WorldGen.genRand.Next(num2 - num6, num2 + num6 - 2);
@@ -1977,4 +2042,30 @@
  								{
  									bool flag21 = WorldGen.mergeUp;
  									bool flag22 = WorldGen.mergeDown;
+@@ -52842,5 +_,25 @@
+ 		{
+ 			return Main.tile[x, y + 1] != null && Main.tile[x, y + 1].type != 78 && Main.tile[x, y + 1].type != 380 && (Main.tile[x, y].type != 254 || context == TileCuttingContext.TilePlacement);
+ 		}
++
++
++		public static void AddAlt<T>(T alt)
++		{
++			switch (T)
++			{
++				case AltCopper altCopper:
++					AltCopper.Add(altCopper);
++					break;
++				case AltIron altIron:
++					AltIron.Add(altIron);
++					break;
++				case AltSilver altSilver:
++					AltSilver.Add(altSilver);
++					break;
++				case AltGold altGold:
++					AltGold.Add(altGold);
++					break;
++			}
++		}
+ 	}
+ }
 

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -203,7 +203,7 @@
 +			WorldGen.AddAlt(new AltSilver(TileID.Tungsten, ItemID.TungstenBar));
 +			WorldGen.AddAlt(new AltGold(TileID.Gold, ItemID.GoldBar));
 +			WorldGen.AddAlt(new AltGold(TileID.Platinum, ItemID.PlatinumBar));
-+			
++				
  			int dungeonSide = 0;
  			ushort jungleHut = (ushort)WorldGen.genRand.Next(5);
  			int howFar = 0;
@@ -215,7 +215,7 @@
  			WorldGen.AddGenerationPass("Reset", delegate(GenerationProgress progress)
  				{
  					Liquid.ReInit();
-@@ -4637,38 +_,18 @@
+@@ -4637,38 +_,22 @@
  					int num = 86400;
  					Main.slimeRainTime = (double)(-(double)WorldGen.genRand.Next(num * 2, num * 3));
  					Main.cloudBGActive = (float)(-(float)WorldGen.genRand.Next(8640, 86400));
@@ -252,9 +252,13 @@
 -						WorldGen.GoldTierOre = 169;
 -					}
 +					copper = AltCopper.GetAltCopper().oreTileType;
-+					iron = AltIron.GetAltIron().oreTileType
-+					silver = AltSilver.GetAltSilver().oreTileType
-+					gold = AltGold.GetAltGold().oreTileType
++					iron = AltIron.GetAltIron().oreTileType;
++					silver = AltSilver.GetAltSilver().oreTileType;
++					gold = AltGold.GetAltGold().oreTileType;
++					AltCopper.UnchooseAltCopper();
++					AltIron.UnchooseAltIron();
++					AltSilver.UnchooseAltSilver();
++					AltGold.UnchooseAltGold();
 +					WorldGen.CopperTierOre = AltCopper.GetAltCopper().oreTileType;
 +					WorldGen.IronTierOre = AltIron.GetAltIron().oreTileType;
 +					WorldGen.SilverTierOre = AltSilver.GetAltSilver().oreTileType;
@@ -2042,7 +2046,7 @@
  								{
  									bool flag21 = WorldGen.mergeUp;
  									bool flag22 = WorldGen.mergeDown;
-@@ -52842,5 +_,25 @@
+@@ -52842,5 +_,27 @@
  		{
  			return Main.tile[x, y + 1] != null && Main.tile[x, y + 1].type != 78 && Main.tile[x, y + 1].type != 380 && (Main.tile[x, y].type != 254 || context == TileCuttingContext.TilePlacement);
  		}
@@ -2064,6 +2068,8 @@
 +				case AltGold altGold:
 +					AltGold.Add(altGold);
 +					break;
++				default:
++					throw Exception("Invalid alt added")
 +			}
 +		}
  	}

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -920,6 +920,130 @@
  						{
  							Main.tile[k, l].type = type;
  							WorldGen.SquareTileFrame(k, l, true);
+@@ -26612,25 +_,21 @@
+ 			{
+ 				if (WorldGen.oreTier1 == -1)
+ 				{
+-					WorldGen.oreTier1 = 107;
+-					if (WorldGen.genRand.Next(2) == 0)
+-					{
+-						WorldGen.oreTier1 = 221;
+-					}
+-				}
+-				int num5 = 12;
+-				if (WorldGen.oreTier1 == 221)
+-				{
+-					num5 += 9;
+-					num3 *= 0.9f;
+-				}
++					AltCobalt.UnchooseAltCobalt();
++				}
++				else if (AltCobalt.unchosen())
++				{
++					AltCobalt.tryFind(WorldGen.oreTier1);
++				}
++				WorldGen.oreTier1 = AltCobalt.GetAltCobalt().oreTileType;
++				num3 *= AltCobalt.GetAltCobalt().abundanceMultiplier;
+ 				if (Main.netMode == 0)
+ 				{
+-					Main.NewText(Lang.misc[num5].Value, 50, 255, 130, false);
++					Main.NewText(AltCobalt.GetAltCobalt().oreBlessingText, 50, 255, 130, false);
+ 				}
+ 				else if (Main.netMode == 2)
+ 				{
+-					NetMessage.BroadcastChatMessage(NetworkText.FromKey(Lang.misc[num5].Key, new object[0]), new Color(50, 255, 130), -1);
++					NetMessage.BroadcastChatMessage(NetworkText.FromLiteral(AltCobalt.GetAltCobalt().oreBlessingText), new Color(50, 255, 130), -1);
+ 				}
+ 				num = WorldGen.oreTier1;
+ 				num3 *= 1.05f;
+@@ -26639,25 +_,22 @@
+ 			{
+ 				if (WorldGen.oreTier2 == -1)
+ 				{
+-					WorldGen.oreTier2 = 108;
+-					if (WorldGen.genRand.Next(2) == 0)
+-					{
+-						WorldGen.oreTier2 = 222;
+-					}
+-				}
+-				int num6 = 13;
+-				if (WorldGen.oreTier2 == 222)
+-				{
+-					num6 += 9;
+-					num3 *= 0.9f;
+-				}
++					AltMythril.UnchooseAltMythril();
++				}
++				else if (AltMythril.unchosen())
++				{
++					AltMythril.tryFind(WorldGen.oreTier2);
++				}
++
++				WorldGen.oreTier2 = AltMythril.GetAltMythril().oreTileType;
++				num3 *= AltMythril.GetAltMythril().abundanceMultiplier;
+ 				if (Main.netMode == 0)
+ 				{
+-					Main.NewText(Lang.misc[num6].Value, 50, 255, 130, false);
++					Main.NewText(AltMythril.GetAltMythril().oreBlessingText, 50, 255, 130, false);
+ 				}
+ 				else if (Main.netMode == 2)
+ 				{
+-					NetMessage.BroadcastChatMessage(NetworkText.FromKey(Lang.misc[num6].Key, new object[0]), new Color(50, 255, 130), -1);
++					NetMessage.BroadcastChatMessage(NetworkText.FromLiteral(AltMythril.GetAltMythril().oreBlessingText), new Color(50, 255, 130), -1);
+ 				}
+ 				num = WorldGen.oreTier2;
+ 			}
+@@ -26665,25 +_,22 @@
+ 			{
+ 				if (WorldGen.oreTier3 == -1)
+ 				{
+-					WorldGen.oreTier3 = 111;
+-					if (WorldGen.genRand.Next(2) == 0)
+-					{
+-						WorldGen.oreTier3 = 223;
+-					}
+-				}
+-				int num7 = 14;
+-				if (WorldGen.oreTier3 == 223)
+-				{
+-					num7 += 9;
+-					num3 *= 0.9f;
+-				}
++					AltAdamantite.UnchooseAltAdamantite();
++				}
++				else if (AltAdamantite.unchosen())
++				{
++					AltAdamantite.tryFind(WorldGen.oreTier3);
++				}
++
++				WorldGen.oreTier3 = AltAdamantite.GetAltAdamantite().oreTileType;
++				num3 *= AltAdamantite.GetAltAdamantite().abundanceMultiplier
+ 				if (Main.netMode == 0)
+ 				{
+-					Main.NewText(Lang.misc[num7].Value, 50, 255, 130, false);
++					Main.NewText(AltAdamantite.GetAltAdamantite().oreBlessingText, 50, 255, 130, false);
+ 				}
+ 				else if (Main.netMode == 2)
+ 				{
+-					NetMessage.BroadcastChatMessage(NetworkText.FromKey(Lang.misc[num7].Key, new object[0]), new Color(50, 255, 130), -1);
++					NetMessage.BroadcastChatMessage(NetworkText.FromLiteral(AltAdamantite.GetAltAdamantite().oreBlessingText), new Color(50, 255, 130), -1);
+ 				}
+ 				num = WorldGen.oreTier3;
+ 			}
+@@ -26692,11 +_,11 @@
+ 			{
+ 				int i2 = WorldGen.genRand.Next(100, Main.maxTilesX - 100);
+ 				double num9 = Main.worldSurface;
+-				if (num == 108 || num == 222)
++				if (WorldGen.altarCount % 3 == 1)
+ 				{
+ 					num9 = Main.rockLayer;
+ 				}
+-				if (num == 111 || num == 223)
++				if (WorldGen.altarCount % 3 == 2)
+ 				{
+ 					num9 = (Main.rockLayer + Main.rockLayer + (double)Main.maxTilesY) / 3.0;
+ 				}
 @@ -26773,7 +_,7 @@
  				{
  					flag = true;


### PR DESCRIPTION
<!-- 

PLEASE READ the following requirements:

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* If applicable, provide Example Mod usage (example code) in the 'Sample usage' section
* If a header/description isn't applicable to your PR, please add "N/A" or "Not Applicable" 

We are happy as long as you follow this template. Feel free to add any extra headings yourself if you deem them necessary or useful.
-->
### Description of the Change
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->
New function:
`public static void WorldGen.AddAlt<T>(T alt)`
This takes in one of the new classes:
AltCopper, AltIron, AltSilver, AltGold, AltCobalt, AltMythril, AltAdamantite
When initialised, these all must take the ore tile to be placed and the bar item for use in certain treasure chests. The AddAlt function adds the new alt ores to a list of them, each contained within the relevant class. When the world is generated, before the 'Reset' task, the vanilla ores are added, and then in the 'Reset' task, the ores to use are chosen and assigned to the relevant variables.

In addition, the ore in the MiningExplosivesBiome is now specified in a compatible way with this.

### Alternate designs
<!-- Explain what other alternatives were considered and why the proposed version was selected. If none, feel free to mark this as not applicable. -->
One alternative was to have seperate `AddAltCopper()`, `AddAltIron()` etc.. I decided not to do this, as the method I decided on made it possible in the near future for mods to easily let other mods add alt ores to them.

### Why this should be merged into tModLoader
<!-- Explain why this functionality should be in our API as opposed to something standalone (like a mod/framework etc.) -->
DO NOT MERGE THIS YET - It isn't ready. I just want some feedback before I implement many other alts (i.e. HM ores, Hellstone, Evil Biomes, Other Biomes, more...)
I'm also not quite sure where the AddAlt function, and the AltCopper, AltIron, etc. classes should go.

Eventually, it should be merged, as this adds in functionality that cannot be added by a mod, even with TerrariaHooks (at least, not easily, and certainly not flexibly)

### Benefits
<!-- What benefits will be realized by the code change? -->
Mods will be able to add alt ores of their own, and hopefully (eventually) alt other stuff as well

### Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? If none, feel free to mark this as not applicable. An example negative impact can be: "Increases the code complexity of class X" or "Requires an additional step in X process to complete Y thing" -->
Not applicable (as far as I can think)

### Applicable Issues
<!-- Enter any applicable issues here, these can be issues regarding your solution/implementation, but also feel free to mention any existing issues that this merge aims to target or solve. -->
Any mod that replaces the 'reset' task in World Gen will break this feature.

### Sample Usage
<!-- Please provide a code sample that demonstrates how your changes are applicable in the real world, or how your changes reflect on mods' code, preferably code that we can use in Example Mod -->
In the ModWorld of ExampleMod:
```C
public override void ModifyWorldGenTasks(List<GenPass> tasks, ref float totalWeight)
{
	int resetTask = tasks.FindIndex(genpass => genpass.Name == "Reset");
	if (reset != -1)
	{
		tasks.Insert(reset, new PassLegacy("Adding Alt Ores", delegate
		{
			WorldGen.Add(new AltCopper(mod.TileType<ExampleCopperTierOre>(), mod.ItemType<ExampleCopperTierBar>()));
		}));
	}
}
```
This would give the following behaviour:
1/3 of the time, Copper Ore spawns
1/3 of the time, Tin Ore spawns
1/3 of the time, ExampleCopperTierOre spawns instead

Of course, if you add more copper tier ores, those probabilities will decrease.

