### PR TITLE
Fixes a NRE crash if an item has a prefix > 83 but no ModPrefix

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria.ModLoader.IO/ItemIO.cs
@@ -35,8 +35,10 @@ namespace Terraria.ModLoader.IO
 
 			if (item.prefix >= PrefixID.Count) {
 				ModPrefix modPrefix = ModPrefix.GetPrefix(item.prefix);
-				tag.Set("modPrefixMod", modPrefix.mod.Name);
-				tag.Set("modPrefixName", modPrefix.Name);
+				if (modPrefix != null) {
+					tag.Set("modPrefixMod", modPrefix.mod.Name);
+					tag.Set("modPrefixName", modPrefix.Name);
+				}
 			}
 
 			if (item.stack > 1)


### PR DESCRIPTION
Just a quick fix to prevent crashes on save.
However prefixes that would normally crash are instead ignored and discarded.

Example of crash:
1: Set a prefix on an item >83 and >ModPrefix defined max, such as 255.
2: Exit the world and you'll crash to desktop without a message when saving is done.
3: You can still load the world and character, but regardless if you have the offending mod loaded or not, it will still crash on exit save.

My mod, Item Qualities and Durability used to set a prefix of 255 if the prefix is 0 to trick the tooltips in displaying stat changes when the item's quality changes. However it seems since ModPrefix was added, it would just crash like this.
Either way, said mod will be using a different way of doing this rather than the invalid prefix method.