### PR TITLE
Forces HiDef if grahpics device supports it

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -653,14 +653,16 @@
  			}
  			return result;
  		}
-@@ -7482,15 +_,11 @@
+@@ -7482,15 +_,17 @@
  			}
  			Main.Configuration.Get<bool>("Support4K", ref Main.Support4K);
  			bool flag = Main.Support4K && base.GraphicsDevice.Adapter.IsProfileSupported(GraphicsProfile.HiDef);
--			if (GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width <= 1920 && GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height <= 1200)
--			{
--				flag = false;
--			}
++			/* tModLoader will attempt to use HiDef even if the computer resolution doesn't need it to support newer shaders.
+ 			if (GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width <= 1920 && GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height <= 1200)
+ 			{
+ 				flag = false;
+ 			}
++			*/
  			if (Main.Support4K && flag)
  			{
  				Main.SetGraphicsProfile(GraphicsProfile.HiDef);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -285,20 +285,31 @@
  		}
  
  		public static void InitializeItemAnimations()
-@@ -2566,9 +_,10 @@
+@@ -2566,10 +_,20 @@
  					Main._renderTargetMaxSize = 2048;
  					break;
  				case GraphicsProfile.HiDef:
 -					Main.maxScreenW = 4096;
 -					Main.maxScreenH = 4096;
 -					Main._renderTargetMaxSize = 4096;
-+					int hiRes = ModLoader.ModLoader.allowGreaterResolutions ? 8192 : 4096;
-+					Main.maxScreenW = hiRes;
-+					Main.maxScreenH = hiRes;
-+					Main._renderTargetMaxSize = hiRes;
- 					Main.TrySupporting8K();
+-					Main.TrySupporting8K();
++					if(Main.Support4K) 
++					{
++						int hiRes = ModLoader.ModLoader.allowGreaterResolutions ? 8192 : 4096;
++						Main.maxScreenW = hiRes;
++						Main.maxScreenH = hiRes;
++						Main._renderTargetMaxSize = hiRes;
++						Main.TrySupporting8K();
++					}
++					else
++					{
++						Main.maxScreenW = 1920;
++						Main.maxScreenH = 1200;
++						Main._renderTargetMaxSize = 2048;
++					}
  					break;
  			}
+ 			try
 @@ -2622,6 +_,7 @@
  				flag2 = false;
  				Main.anglerQuest = Main.rand.Next(Main.anglerQuestItemNetIDs.Length);
@@ -653,11 +664,10 @@
  			}
  			return result;
  		}
-@@ -7480,17 +_,9 @@
- 			{
+@@ -7481,16 +_,9 @@
  				TexturePackSupport.Enabled = true;
  			}
--			Main.Configuration.Get<bool>("Support4K", ref Main.Support4K);
+ 			Main.Configuration.Get<bool>("Support4K", ref Main.Support4K);
 -			bool flag = Main.Support4K && base.GraphicsDevice.Adapter.IsProfileSupported(GraphicsProfile.HiDef);
 -			if (GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width <= 1920 && GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height <= 1200)
 -			{
@@ -665,11 +675,10 @@
 -			}
 -			if (Main.Support4K && flag)
 -			{
--				Main.SetGraphicsProfile(GraphicsProfile.HiDef);
++			if (GraphicsDevice.Adapter.IsProfileSupported(GraphicsProfile.HiDef))
+ 				Main.SetGraphicsProfile(GraphicsProfile.HiDef);
 -			}
 -			TexturePackSupport.FindTexturePack();
-+			GraphicsDevice.Adapter.IsProfileSupported(GraphicsProfile.HiDef);
-+				SetGraphicsProfile(GraphicsProfile.HiDef);
 +			TexturePackSupport.FindTexturePacks();
  			TextureManager.Initialize();
  			this.mapSectionTexture = new RenderTarget2D(base.GraphicsDevice, 200, 150);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -285,31 +285,20 @@
  		}
  
  		public static void InitializeItemAnimations()
-@@ -2566,10 +_,20 @@
+@@ -2566,9 +_,10 @@
  					Main._renderTargetMaxSize = 2048;
  					break;
  				case GraphicsProfile.HiDef:
 -					Main.maxScreenW = 4096;
 -					Main.maxScreenH = 4096;
 -					Main._renderTargetMaxSize = 4096;
--					Main.TrySupporting8K();
-+					if(Main.Support4K) 
-+					{
-+						int hiRes = ModLoader.ModLoader.allowGreaterResolutions ? 8192 : 4096;
-+						Main.maxScreenW = hiRes;
-+						Main.maxScreenH = hiRes;
-+						Main._renderTargetMaxSize = hiRes;
-+						Main.TrySupporting8K();
-+					}
-+					else
-+					{
-+						Main.maxScreenW = 1920;
-+						Main.maxScreenH = 1200;
-+						Main._renderTargetMaxSize = 2048;
-+					}
++					int hiRes = ModLoader.ModLoader.allowGreaterResolutions ? 8192 : 4096;
++					Main.maxScreenW = hiRes;
++					Main.maxScreenH = hiRes;
++					Main._renderTargetMaxSize = hiRes;
+ 					Main.TrySupporting8K();
  					break;
  			}
- 			try
 @@ -2622,6 +_,7 @@
  				flag2 = false;
  				Main.anglerQuest = Main.rand.Next(Main.anglerQuestItemNetIDs.Length);
@@ -664,20 +653,18 @@
  			}
  			return result;
  		}
-@@ -7481,16 +_,9 @@
- 				TexturePackSupport.Enabled = true;
+@@ -7482,15 +_,11 @@
  			}
  			Main.Configuration.Get<bool>("Support4K", ref Main.Support4K);
--			bool flag = Main.Support4K && base.GraphicsDevice.Adapter.IsProfileSupported(GraphicsProfile.HiDef);
+ 			bool flag = Main.Support4K && base.GraphicsDevice.Adapter.IsProfileSupported(GraphicsProfile.HiDef);
 -			if (GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width <= 1920 && GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height <= 1200)
 -			{
 -				flag = false;
 -			}
--			if (Main.Support4K && flag)
--			{
-+			if (GraphicsDevice.Adapter.IsProfileSupported(GraphicsProfile.HiDef))
+ 			if (Main.Support4K && flag)
+ 			{
  				Main.SetGraphicsProfile(GraphicsProfile.HiDef);
--			}
+ 			}
 -			TexturePackSupport.FindTexturePack();
 +			TexturePackSupport.FindTexturePacks();
  			TextureManager.Initialize();

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -653,11 +653,23 @@
  			}
  			return result;
  		}
-@@ -7490,7 +_,7 @@
+@@ -7480,17 +_,9 @@
  			{
- 				Main.SetGraphicsProfile(GraphicsProfile.HiDef);
+ 				TexturePackSupport.Enabled = true;
  			}
+-			Main.Configuration.Get<bool>("Support4K", ref Main.Support4K);
+-			bool flag = Main.Support4K && base.GraphicsDevice.Adapter.IsProfileSupported(GraphicsProfile.HiDef);
+-			if (GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width <= 1920 && GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height <= 1200)
+-			{
+-				flag = false;
+-			}
+-			if (Main.Support4K && flag)
+-			{
+-				Main.SetGraphicsProfile(GraphicsProfile.HiDef);
+-			}
 -			TexturePackSupport.FindTexturePack();
++			GraphicsDevice.Adapter.IsProfileSupported(GraphicsProfile.HiDef);
++				SetGraphicsProfile(GraphicsProfile.HiDef);
 +			TexturePackSupport.FindTexturePacks();
  			TextureManager.Initialize();
  			this.mapSectionTexture = new RenderTarget2D(base.GraphicsDevice, 200, 150);


### PR DESCRIPTION
### Description of the Change
Forces the graphics profile into HiDef if the graphics device supports it.

### Alternate designs
Not applicable

### Why this should be merged into tModLoader
Allows mods to utilize SM3 shaders and other HiDef features if graphics device supports it.

### Benefits
SM3 shaders!

### Possible drawbacks
None

### Applicable Issues
#488 

### Sample Usage
```cs
Effect shader = null;

if (graphics.GraphicsProfile == GraphicsProfile.HiDef)
	shader = new Effect(graphics.GraphicsDevice, sm3ByteCode);
else // Device could not start HiDef, fallback to sm2 shader
	shader = new Effect(graphics.GraphicsDevice, sm2ByteCode);
```


