### PR TITLE
Allow mods which have noCompile == true to enable editAndContinue in build.txt

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/ModCompile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModCompile.cs
@@ -351,6 +351,15 @@ namespace Terraria.ModLoader
 					status.LogError(Language.GetTextValue("tModLoader.BuildErrorMissingDllFiles", string.Join(", ", missing)));
 					return false;
 				}
+
+				if (Program.LaunchParameters.ContainsKey("-eac") && pdb != null) {
+					if (!windows) {
+						status.LogError(Language.GetTextValue("tModLoader.BuildErrorEACWindowsOnly"));
+						return false;
+					}
+
+					mod.properties.editAndContinue = true;
+				}
 			}
 			else {
 				List<LocalMod> refMods;


### PR DESCRIPTION
### Description of the Change

When a mod was compiled with both noCompile == true and editAndContinue == true in build.txt, ModCompile did not save the editAndContinue flag to the .tmod file. This change makes ModCompile save the editAndContinue flag as long as the mod has a Windows.pdb file.

### Alternate designs

N/A

### Why this should be merged into tModLoader

Edit-and-continue speeds up the development cycle. It makes sense for modders who have to use noCompile == true to be able to use it, especially since the change required is minimal.

### Benefits

Modders who need to use noCompile == true will be able to use edit-and-continue.

### Possible drawbacks

N/A

### Applicable Issues

Commit 30231fdb80195a5a6014b0fb3cd4b8865fa05f15 disables edit-and-continue in AssemblyManager for all users. Since the disabling appears to be temporary while related, active development is done, I tested my changes by re-enabling edit-and-continue locally. They will not have any effect for other users until the entire feature is re-enabled.

### Sample Usage

build.txt:

author = tansheron
version = 0.1
displayName = My Mod
noCompile = true
editAndContinue = true
includePDB = true