### PR TITLE
Small Fix to GlobalItem/ModItem PickAmmo

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -206,17 +206,17 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to modify the projectile created by a weapon based on the ammo it is using.
 		/// </summary>
-		/// <param name="item">The ammo item</param>
 		/// <param name="shooter">The item that is using this ammo</param>
+		/// <param name="item">The ammo item</param>
 		/// <param name="player">The player using the item</param>
 		/// <param name="type">The ID of the projectile shot</param>
 		/// <param name="speed">The speed of the projectile shot</param>
 		/// <param name="damage">The damage of the projectile shot</param>
 		/// <param name="knockback">The speed of the projectile shot</param>
-		public virtual void PickAmmo(Item item, Item shooter, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
+		public virtual void PickAmmo(Item shooter, Item item, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 		}
 
-		[Obsolete("PickAmmo now has a shooter parameter that represents the item using the ammo.", true)]
+		[Obsolete("PickAmmo now has a shooter parameter that represents the item using the ammo.")]
 		public virtual void PickAmmo(Item item, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -207,13 +207,13 @@ namespace Terraria.ModLoader
 		/// Allows you to modify the projectile created by a weapon based on the ammo it is using.
 		/// </summary>
 		/// <param name="shooter">The item that is using this ammo</param>
-		/// <param name="item">The ammo item</param>
+		/// <param name="ammo">The ammo item</param>
 		/// <param name="player">The player using the item</param>
 		/// <param name="type">The ID of the projectile shot</param>
 		/// <param name="speed">The speed of the projectile shot</param>
 		/// <param name="damage">The damage of the projectile shot</param>
 		/// <param name="knockback">The speed of the projectile shot</param>
-		public virtual void PickAmmo(Item shooter, Item item, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
+		public virtual void PickAmmo(Item shooter, Item ammo, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 		}
 
 		[Obsolete("PickAmmo now has a shooter parameter that represents the item using the ammo.")]

--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -206,17 +206,17 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to modify the projectile created by a weapon based on the ammo it is using.
 		/// </summary>
-		/// <param name="shooter">The item that is using this ammo</param>
+		/// <param name="weapon">The item that is using this ammo</param>
 		/// <param name="ammo">The ammo item</param>
 		/// <param name="player">The player using the item</param>
 		/// <param name="type">The ID of the projectile shot</param>
 		/// <param name="speed">The speed of the projectile shot</param>
 		/// <param name="damage">The damage of the projectile shot</param>
 		/// <param name="knockback">The speed of the projectile shot</param>
-		public virtual void PickAmmo(Item shooter, Item ammo, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
+		public virtual void PickAmmo(Item weapon, Item ammo, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 		}
 
-		[Obsolete("PickAmmo now has a shooter parameter that represents the item using the ammo.")]
+		[Obsolete("PickAmmo now has a weapon parameter that represents the item using the ammo.")]
 		public virtual void PickAmmo(Item item, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -207,11 +207,16 @@ namespace Terraria.ModLoader
 		/// Allows you to modify the projectile created by a weapon based on the ammo it is using.
 		/// </summary>
 		/// <param name="item">The ammo item</param>
-		/// <param name="player"></param>
-		/// <param name="type"></param>
-		/// <param name="speed"></param>
-		/// <param name="damage"></param>
-		/// <param name="knockback"></param>
+		/// <param name="shooter">The item that is using this ammo</param>
+		/// <param name="player">The player using the item</param>
+		/// <param name="type">The ID of the projectile shot</param>
+		/// <param name="speed">The speed of the projectile shot</param>
+		/// <param name="damage">The damage of the projectile shot</param>
+		/// <param name="knockback">The speed of the projectile shot</param>
+		public virtual void PickAmmo(Item item, Item shooter, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
+		}
+
+		[Obsolete("PickAmmo now has a shooter parameter that represents the item using the ammo.", true)]
 		public virtual void PickAmmo(Item item, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -434,18 +434,23 @@ namespace Terraria.ModLoader
 			return item.modItem == null || !item.modItem.OnlyShootOnSwing || player.itemAnimation == player.itemAnimationMax - 1;
 		}
 
-		private delegate void DelegatePickAmmo(Item item, Player player, ref int type, ref float speed, ref int damage, ref float knockback);
+		private delegate void DelegateOldPickAmmo(Item item, Player player, ref int type, ref float speed, ref int damage, ref float knockback); // deprecated
+		private static HookList HookOldPickAmmo = AddHook<DelegateOldPickAmmo>(g => g.PickAmmo); // deprecated
+
+		private delegate void DelegatePickAmmo(Item shooter, Item ammo, Player player, ref int type, ref float speed, ref int damage, ref float knockback);
 		private static HookList HookPickAmmo = AddHook<DelegatePickAmmo>(g => g.PickAmmo);
 		/// <summary>
 		/// Calls ModItem.PickAmmo, then all GlobalItem.PickAmmo hooks.
 		/// </summary>
-		public static void PickAmmo(Item shooter, Item item, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
-			item.modItem?.PickAmmo(shooter, player, ref type, ref speed, ref damage, ref knockback);
-			item.modItem?.PickAmmo(player, ref type, ref speed, ref damage, ref knockback); // deprecated
+		public static void PickAmmo(Item shooter, Item ammo, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
+			ammo.modItem?.PickAmmo(shooter, player, ref type, ref speed, ref damage, ref knockback);
+			ammo.modItem?.PickAmmo(player, ref type, ref speed, ref damage, ref knockback); // deprecated
 
 			foreach (var g in HookPickAmmo.arr) {
-				g.Instance(item).PickAmmo(shooter, item, player, ref type, ref speed, ref damage, ref knockback);
-				g.Instance(item).PickAmmo(item, player, ref type, ref speed, ref damage, ref knockback); // deprecated
+				g.Instance(ammo).PickAmmo(shooter, ammo, player, ref type, ref speed, ref damage, ref knockback);
+			}
+			foreach (var g in HookOldPickAmmo.arr) {
+				g.Instance(ammo).PickAmmo(ammo, player, ref type, ref speed, ref damage, ref knockback); // deprecated
 			}
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -439,7 +439,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Calls ModItem.PickAmmo, then all GlobalItem.PickAmmo hooks.
 		/// </summary>
-		public static void PickAmmo(Item item, Item shooter, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
+		public static void PickAmmo(Item shooter, Item item, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 			item.modItem?.PickAmmo(shooter, player, ref type, ref speed, ref damage, ref knockback);
 			item.modItem?.PickAmmo(player, ref type, ref speed, ref damage, ref knockback); // deprecated
 

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -437,17 +437,17 @@ namespace Terraria.ModLoader
 		private delegate void DelegateOldPickAmmo(Item item, Player player, ref int type, ref float speed, ref int damage, ref float knockback); // deprecated
 		private static HookList HookOldPickAmmo = AddHook<DelegateOldPickAmmo>(g => g.PickAmmo); // deprecated
 
-		private delegate void DelegatePickAmmo(Item shooter, Item ammo, Player player, ref int type, ref float speed, ref int damage, ref float knockback);
+		private delegate void DelegatePickAmmo(Item weapon, Item ammo, Player player, ref int type, ref float speed, ref int damage, ref float knockback);
 		private static HookList HookPickAmmo = AddHook<DelegatePickAmmo>(g => g.PickAmmo);
 		/// <summary>
 		/// Calls ModItem.PickAmmo, then all GlobalItem.PickAmmo hooks.
 		/// </summary>
-		public static void PickAmmo(Item shooter, Item ammo, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
-			ammo.modItem?.PickAmmo(shooter, player, ref type, ref speed, ref damage, ref knockback);
+		public static void PickAmmo(Item weapon, Item ammo, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
+			ammo.modItem?.PickAmmo(weapon, player, ref type, ref speed, ref damage, ref knockback);
 			ammo.modItem?.PickAmmo(player, ref type, ref speed, ref damage, ref knockback); // deprecated
 
 			foreach (var g in HookPickAmmo.arr) {
-				g.Instance(ammo).PickAmmo(shooter, ammo, player, ref type, ref speed, ref damage, ref knockback);
+				g.Instance(ammo).PickAmmo(weapon, ammo, player, ref type, ref speed, ref damage, ref knockback);
 			}
 			foreach (var g in HookOldPickAmmo.arr) {
 				g.Instance(ammo).PickAmmo(ammo, player, ref type, ref speed, ref damage, ref knockback); // deprecated

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -439,11 +439,14 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Calls ModItem.PickAmmo, then all GlobalItem.PickAmmo hooks.
 		/// </summary>
-		public static void PickAmmo(Item item, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
-			item.modItem?.PickAmmo(player, ref type, ref speed, ref damage, ref knockback);
+		public static void PickAmmo(Item item, Item shooter, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
+			item.modItem?.PickAmmo(shooter, player, ref type, ref speed, ref damage, ref knockback);
+			item.modItem?.PickAmmo(player, ref type, ref speed, ref damage, ref knockback); // deprecated
 
-			foreach (var g in HookPickAmmo.arr)
-				g.Instance(item).PickAmmo(item, player, ref type, ref speed, ref damage, ref knockback);
+			foreach (var g in HookPickAmmo.arr) {
+				g.Instance(item).PickAmmo(shooter, item, player, ref type, ref speed, ref damage, ref knockback);
+				g.Instance(item).PickAmmo(item, player, ref type, ref speed, ref damage, ref knockback); // deprecated
+			}
 		}
 
 		private static HookList HookConsumeAmmo = AddHook<Func<Item, Player, bool>>(g => g.ConsumeAmmo);

--- a/patches/tModLoader/Terraria.ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModItem.cs
@@ -307,7 +307,7 @@ namespace Terraria.ModLoader
 		public virtual void PickAmmo(Item shooter, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 		}
 		
-		[Obsolete("PickAmmo now has a shooter parameter that represents the item using the ammo.", true)]
+		[Obsolete("PickAmmo now has a shooter parameter that represents the item using the ammo.")]
 		public virtual void PickAmmo(Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModItem.cs
@@ -298,11 +298,16 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to modify the projectile created by a weapon based on the ammo it is using. This hook is called on the ammo.
 		/// </summary>
-		/// <param name="player"></param>
-		/// <param name="type"></param>
-		/// <param name="speed"></param>
-		/// <param name="damage"></param>
-		/// <param name="knockback"></param>
+		/// <param name="shooter">The item that is using this ammo</param>
+		/// <param name="player">The player using the item</param>
+		/// <param name="type">The ID of the projectile shot</param>
+		/// <param name="speed">The speed of the projectile shot</param>
+		/// <param name="damage">The damage of the projectile shot</param>
+		/// <param name="knockback">The speed of the projectile shot</param>
+		public virtual void PickAmmo(Item shooter, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
+		}
+		
+		[Obsolete("PickAmmo now has a shooter parameter that represents the item using the ammo.", true)]
 		public virtual void PickAmmo(Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModItem.cs
@@ -298,16 +298,16 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to modify the projectile created by a weapon based on the ammo it is using. This hook is called on the ammo.
 		/// </summary>
-		/// <param name="shooter">The item that is using this ammo</param>
+		/// <param name="weapon">The item that is using this ammo</param>
 		/// <param name="player">The player using the item</param>
 		/// <param name="type">The ID of the projectile shot</param>
 		/// <param name="speed">The speed of the projectile shot</param>
 		/// <param name="damage">The damage of the projectile shot</param>
 		/// <param name="knockback">The speed of the projectile shot</param>
-		public virtual void PickAmmo(Item shooter, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
+		public virtual void PickAmmo(Item weapon, Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 		}
 		
-		[Obsolete("PickAmmo now has a shooter parameter that represents the item using the ammo.")]
+		[Obsolete("PickAmmo now has a weapon parameter that represents the item using the ammo.")]
 		public virtual void PickAmmo(Player player, ref int type, ref float speed, ref int damage, ref float knockback) {
 		}
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5515,7 +5515,7 @@
  					Damage = (int)((double)((float)Damage) * 1.2);
  				}
  				KnockBack += item.knockBack;
-+				ItemLoader.PickAmmo(item, this, ref shoot, ref speed, ref Damage, ref KnockBack);
++				ItemLoader.PickAmmo(item, sItem, this, ref shoot, ref speed, ref Damage, ref KnockBack);
  				bool flag2 = dontConsume;
  				if (sItem.type == 3245)
  				{

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5515,7 +5515,7 @@
  					Damage = (int)((double)((float)Damage) * 1.2);
  				}
  				KnockBack += item.knockBack;
-+				ItemLoader.PickAmmo(item, sItem, this, ref shoot, ref speed, ref Damage, ref KnockBack);
++				ItemLoader.PickAmmo(sItem, item, this, ref shoot, ref speed, ref Damage, ref KnockBack);
  				bool flag2 = dontConsume;
  				if (sItem.type == 3245)
  				{


### PR DESCRIPTION
### Description of the Change

Made it so GlobalItem/ModItem PickAmmo receives the item that's using the ammo as an argument, and made the old methods obsolete.

### Why this should be merged into tModLoader

Given that the item using the ammo is important when deciding which projectile to shoot from the weapon in some cases, like flame throwers and rocket launchers in vanilla, not having that as an argument for the aforementioned methods looks like an oversight. Although most of the time the item using the ammo is the item being held by the player, it is still better to have said item as an argument for a better understanding of the method's usage.