### PR TITLE
King and Queen statues compatibility

### DIFF
--- a/ExampleMod/ExampleMod.cs
+++ b/ExampleMod/ExampleMod.cs
@@ -420,6 +420,11 @@ namespace ExampleMod
 						packet.Send(-1, playernumber);
 					}
 					break;
+				case ExampleModMessageType.ExampleTeleportToStatue:
+					if (Main.npc[reader.ReadByte()].modNPC is NPCs.ExamplePerson person && person.npc.active) {
+						person.StatueTeleport();
+					}
+					break;
 				default:
 					Logger.WarnFormat("ExampleMod: Unknown Message type: {0}", msgType);
 					break;
@@ -434,7 +439,8 @@ namespace ExampleMod
 		PuritySpirit,
 		HeroLives,
 		ExamplePlayerSyncPlayer,
-		NonStopPartyChanged
+		NonStopPartyChanged,
+		ExampleTeleportToStatue
 	}
 
 	/*public static class ExampleModExtensions

--- a/ExampleMod/NPCs/ExamplePerson.cs
+++ b/ExampleMod/NPCs/ExamplePerson.cs
@@ -19,6 +19,11 @@ namespace ExampleMod.NPCs
 			return mod.Properties.Autoload;
 		}
 
+		// Make this Town NPC teleport to the King and/or Queen statue when triggered.
+		public override bool AddToKingStatue => true;
+
+		public override bool AddToQueenStatue => true;
+
 		public override void SetStaticDefaults() {
 			// DisplayName automatically assigned from .lang files, but the commented line below is the normal approach.
 			// DisplayName.SetDefault("Example Person");

--- a/ExampleMod/NPCs/ExamplePerson.cs
+++ b/ExampleMod/NPCs/ExamplePerson.cs
@@ -260,11 +260,7 @@ namespace ExampleMod.NPCs
 		}
 
 		// Make this Town NPC teleport to the King and/or Queen statue when triggered.
-		public override bool CanGoToKingStatue() {
-			return true;
-		}
-
-		public override bool CanGoToQueenStatue() {
+		public override bool CanGoToStatue(bool toKingStatue) {
 			return true;
 		}
 

--- a/ExampleMod/NPCs/ExamplePerson.cs
+++ b/ExampleMod/NPCs/ExamplePerson.cs
@@ -1,4 +1,6 @@
+using System;
 using ExampleMod.Items;
+using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.Localization;
@@ -18,11 +20,6 @@ namespace ExampleMod.NPCs
 			name = "Example Person";
 			return mod.Properties.Autoload;
 		}
-
-		// Make this Town NPC teleport to the King and/or Queen statue when triggered.
-		public override bool AddToKingStatue => true;
-
-		public override bool AddToQueenStatue => true;
 
 		public override void SetStaticDefaults() {
 			// DisplayName automatically assigned from .lang files, but the commented line below is the normal approach.
@@ -260,6 +257,42 @@ namespace ExampleMod.NPCs
 
 		public override void NPCLoot() {
 			Item.NewItem(npc.getRect(), mod.ItemType<Items.Armor.ExampleCostume>());
+		}
+
+		// Make this Town NPC teleport to the King and/or Queen statue when triggered.
+		public override bool CanGoToKingStatue() {
+			return true;
+		}
+
+		public override bool CanGoToQueenStatue() {
+			return true;
+		}
+
+		// Make something happen when the npc teleports to a statue. Since this method only runs server side, any visual effects like dusts or gores have to be synced across all clients manually.
+		public override void OnGoToStatue(bool toKingStatue) {
+			if (Main.netMode == NetmodeID.Server) {
+				ModPacket packet = mod.GetPacket();
+				packet.Write((byte)ExampleModMessageType.ExampleTeleportToStatue);
+				packet.Write((byte)npc.whoAmI);
+				packet.Send();
+			}
+			else {
+				StatueTeleport();
+			}
+		}
+
+		// Create a square of pixels around the NPC on teleport.
+		public void StatueTeleport() {
+			for (int i = 0; i < 30; i++) {
+				Vector2 position = Main.rand.NextVector2Square(-20, 21);
+				if (Math.Abs(position.X) > Math.Abs(position.Y)) {
+					position.X = Math.Sign(position.X) * 20;
+				}
+				else {
+					position.Y = Math.Sign(position.Y) * 20;
+				}
+				Dust.NewDustPerfect(position, mod.DustType<Dusts.Pixel>(), Vector2.Zero).noGravity = true;
+			}
 		}
 
 		public override void TownNPCAttackStrength(ref int damage, ref float knockback) {

--- a/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
@@ -501,6 +501,31 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Wether this NPC can be telported to the King statue. Return true to allow the NPC to teleport to the statue, return false to block this NPC from teleporting to the statue, and return null to use the vanilla code for whether the NPC can teleport to the statue. Returns null by default.
+		/// </summary>
+		/// <param name="npc">The NPC</param>
+		public virtual bool? CanGoToKingStatue(NPC npc) {
+			return null;
+		}
+
+		/// <summary>
+		/// Wether this NPC can be telported to the Queen statue. Return true to allow the NPC to teleport to the statue, return false to block this NPC from teleporting to the statue, and return null to use the vanilla code for whether the NPC can teleport to the statue. Returns null by default.
+		/// </summary>
+		/// <param name="npc">The NPC</param>
+		public virtual bool? CanGoToQueenStatue(NPC npc) {
+			return null;
+		}
+
+		/// <summary>
+		/// Allows you to make things happen when this NPC teleports to a King or Queen statue.
+		/// This method is only called server side.
+		/// </summary>
+		/// <param name="npc">The NPC</param>
+		/// <param name="toKingStatue">Whether the NPC was teleported to a King or Queen statue.</param>
+		public virtual void OnGoToStatue(NPC npc, bool toKingStatue) {
+		}
+
+		/// <summary>
 		/// Allows you to modify the stats of town NPCs. Useful for buffing town NPCs when certain bosses are defeated, etc.
 		/// </summary>
 		/// <param name="damageMult"></param>

--- a/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
@@ -501,18 +501,11 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Wether this NPC can be telported to the King statue. Return true to allow the NPC to teleport to the statue, return false to block this NPC from teleporting to the statue, and return null to use the vanilla code for whether the NPC can teleport to the statue. Returns null by default.
+		/// Whether this NPC can be telported a King or Queen statue. Return true to allow the NPC to teleport to the statue, return false to block this NPC from teleporting to the statue, and return null to use the vanilla code for whether the NPC can teleport to the statue. Returns null by default.
 		/// </summary>
 		/// <param name="npc">The NPC</param>
-		public virtual bool? CanGoToKingStatue(NPC npc) {
-			return null;
-		}
-
-		/// <summary>
-		/// Wether this NPC can be telported to the Queen statue. Return true to allow the NPC to teleport to the statue, return false to block this NPC from teleporting to the statue, and return null to use the vanilla code for whether the NPC can teleport to the statue. Returns null by default.
-		/// </summary>
-		/// <param name="npc">The NPC</param>
-		public virtual bool? CanGoToQueenStatue(NPC npc) {
+		/// <param name="toKingStatue">Whether the NPC is being teleported to a King or Queen statue.</param>
+		public virtual bool? CanGoToStatue(NPC npc, bool toKingStatue) {
 			return null;
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
@@ -60,6 +60,14 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual string HeadTexture => Texture + "_Head";
 		/// <summary>
+		/// Wether this town NPC can be telported to the King statue.
+		/// </summary>
+		public virtual bool AddToKingStatue => false;
+		/// <summary>
+		/// Wether this town NPC can be teleported to the Queen statue.
+		/// </summary>
+		public virtual bool AddToQueenStatue => false;
+		/// <summary>
 		/// This file name of this NPC's boss head texture file, to be used in autoloading.
 		/// </summary>
 		public virtual string BossHeadTexture => Texture + "_Head_Boss";

--- a/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
@@ -60,14 +60,6 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual string HeadTexture => Texture + "_Head";
 		/// <summary>
-		/// Wether this town NPC can be telported to the King statue.
-		/// </summary>
-		public virtual bool AddToKingStatue => false;
-		/// <summary>
-		/// Wether this town NPC can be teleported to the Queen statue.
-		/// </summary>
-		public virtual bool AddToQueenStatue => false;
-		/// <summary>
 		/// This file name of this NPC's boss head texture file, to be used in autoloading.
 		/// </summary>
 		public virtual string BossHeadTexture => Texture + "_Head_Boss";
@@ -634,6 +626,28 @@ namespace Terraria.ModLoader
 		/// <param name="shop"></param>
 		/// <param name="nextSlot"></param>
 		public virtual void SetupShop(Chest shop, ref int nextSlot) {
+		}
+
+		/// <summary>
+		/// Wether this NPC can be telported to the King statue. Returns false by default.
+		/// </summary>
+		public virtual bool CanGoToKingStatue() {
+			return false;
+		}
+
+		/// <summary>
+		/// Wether this NPC can be telported to the Queen statue. Returns false by default.
+		/// </summary>
+		public virtual bool CanGoToQueenStatue() {
+			return false;
+		}
+
+		/// <summary>
+		/// Allows you to make things happen when this NPC teleports to a King or Queen statue.
+		/// This method is only called server side.
+		/// </summary>
+		/// <param name="toKingStatue">Whether the NPC was teleported to a King or Queen statue.</param>
+		public virtual void OnGoToStatue(bool toKingStatue) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
@@ -629,16 +629,10 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Wether this NPC can be telported to the King statue. Returns false by default.
+		/// Whether this NPC can be telported to a King or Queen statue. Returns false by default.
 		/// </summary>
-		public virtual bool CanGoToKingStatue() {
-			return false;
-		}
-
-		/// <summary>
-		/// Wether this NPC can be telported to the Queen statue. Returns false by default.
-		/// </summary>
-		public virtual bool CanGoToQueenStatue() {
+		/// <param name="toKingStatue">Whether the NPC is being teleported to a King or Queen statue.</param>
+		public virtual bool CanGoToStatue(bool toKingStatue) {
 			return false;
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
@@ -946,6 +946,84 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private static HookList HookCanGoToKingStatue = AddHook<Func<NPC, bool?>>(g => g.CanGoToKingStatue);
+
+		public static bool CanGoToKingStatue(NPC npc) {
+			bool defaultCanGo = npc.modNPC?.CanGoToKingStatue() ?? false;
+
+			switch (npc.type) {
+				case NPCID.Merchant:
+				case NPCID.Guide:
+				case NPCID.ArmsDealer:
+				case NPCID.Demolitionist:
+				case NPCID.Clothier:
+				case NPCID.GoblinTinkerer:
+				case NPCID.Wizard:
+				case NPCID.SantaClaus:
+				case NPCID.Truffle:
+				case NPCID.DyeTrader:
+				case NPCID.Painter:
+				case NPCID.WitchDoctor:
+				case NPCID.Pirate:
+				case NPCID.LightningBug: // A literal bug
+				case NPCID.Angler:
+				case NPCID.DD2Bartender:
+					defaultCanGo = true;
+					break;
+			}
+
+			foreach (GlobalNPC g in HookCanGoToKingStatue.arr) {
+				bool? canGo = g.Instance(npc).CanGoToKingStatue(npc);
+				if (canGo.HasValue) {
+					if (!canGo.Value) {
+						return false;
+					}
+					defaultCanGo = true;
+				}
+			}
+
+			return defaultCanGo;
+		}
+
+		private static HookList HookCanGoToQueenStatue = AddHook<Func<NPC, bool?>>(g => g.CanGoToQueenStatue);
+
+		public static bool CanGoToQueenStatue(NPC npc) {
+			bool defaultCanGo = npc.modNPC?.CanGoToQueenStatue() ?? false;
+
+			switch (npc.type) {
+				case NPCID.Nurse:
+				case NPCID.Dryad:
+				case NPCID.Mechanic:
+				case NPCID.Steampunker:
+				case NPCID.PartyGirl:
+				case NPCID.Stylist:
+					defaultCanGo = true;
+					break;
+			}
+
+			foreach (GlobalNPC g in HookCanGoToQueenStatue.arr) {
+				bool? canGo = g.Instance(npc).CanGoToQueenStatue(npc);
+				if (canGo.HasValue) {
+					if (!canGo.Value) {
+						return false;
+					}
+					defaultCanGo = true;
+				}
+			}
+
+			return defaultCanGo;
+		}
+
+		private static HookList HookOnGoToStatue = AddHook<Action<NPC, bool>>(g => g.OnGoToStatue);
+
+		public static void OnGoToStatue(NPC npc, bool toKingStatue) {
+			npc.modNPC?.OnGoToStatue(toKingStatue);
+
+			foreach (GlobalNPC g in HookOnGoToStatue.arr) {
+				g.OnGoToStatue(npc, toKingStatue);
+			}
+		}
+
 		private delegate void DelegateBuffTownNPC(ref float damageMult, ref int defense);
 		private static HookList HookBuffTownNPC = AddHook<DelegateBuffTownNPC>(g => g.BuffTownNPC);
 

--- a/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
@@ -946,63 +946,13 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private static HookList HookCanGoToKingStatue = AddHook<Func<NPC, bool?>>(g => g.CanGoToKingStatue);
+		private static HookList HookCanGoToStatue = AddHook<Func<NPC, bool, bool?>>(g => g.CanGoToStatue);
 
-		public static bool CanGoToKingStatue(NPC npc) {
-			bool defaultCanGo = npc.modNPC?.CanGoToKingStatue() ?? false;
+		public static bool CanGoToStatue(NPC npc, bool toKingStatue, bool vanillaCanGo) {
+			bool defaultCanGo = npc.modNPC?.CanGoToStatue(toKingStatue) ?? vanillaCanGo;
 
-			switch (npc.type) {
-				case NPCID.Merchant:
-				case NPCID.Guide:
-				case NPCID.ArmsDealer:
-				case NPCID.Demolitionist:
-				case NPCID.Clothier:
-				case NPCID.GoblinTinkerer:
-				case NPCID.Wizard:
-				case NPCID.SantaClaus:
-				case NPCID.Truffle:
-				case NPCID.DyeTrader:
-				case NPCID.Painter:
-				case NPCID.WitchDoctor:
-				case NPCID.Pirate:
-				case NPCID.LightningBug: // A literal bug
-				case NPCID.Angler:
-				case NPCID.DD2Bartender:
-					defaultCanGo = true;
-					break;
-			}
-
-			foreach (GlobalNPC g in HookCanGoToKingStatue.arr) {
-				bool? canGo = g.Instance(npc).CanGoToKingStatue(npc);
-				if (canGo.HasValue) {
-					if (!canGo.Value) {
-						return false;
-					}
-					defaultCanGo = true;
-				}
-			}
-
-			return defaultCanGo;
-		}
-
-		private static HookList HookCanGoToQueenStatue = AddHook<Func<NPC, bool?>>(g => g.CanGoToQueenStatue);
-
-		public static bool CanGoToQueenStatue(NPC npc) {
-			bool defaultCanGo = npc.modNPC?.CanGoToQueenStatue() ?? false;
-
-			switch (npc.type) {
-				case NPCID.Nurse:
-				case NPCID.Dryad:
-				case NPCID.Mechanic:
-				case NPCID.Steampunker:
-				case NPCID.PartyGirl:
-				case NPCID.Stylist:
-					defaultCanGo = true;
-					break;
-			}
-
-			foreach (GlobalNPC g in HookCanGoToQueenStatue.arr) {
-				bool? canGo = g.Instance(npc).CanGoToQueenStatue(npc);
+			foreach (GlobalNPC g in HookCanGoToStatue.arr) {
+				bool? canGo = g.Instance(npc).CanGoToStatue(npc, toKingStatue);
 				if (canGo.HasValue) {
 					if (!canGo.Value) {
 						return false;

--- a/patches/tModLoader/Terraria/Wiring.cs.patch
+++ b/patches/tModLoader/Terraria/Wiring.cs.patch
@@ -123,7 +123,7 @@
  																for (int num140 = 0; num140 < 200; num140++)
  																{
 -																	if (Main.npc[num140].active && (Main.npc[num140].type == 17 || Main.npc[num140].type == 19 || Main.npc[num140].type == 22 || Main.npc[num140].type == 38 || Main.npc[num140].type == 54 || Main.npc[num140].type == 107 || Main.npc[num140].type == 108 || Main.npc[num140].type == 142 || Main.npc[num140].type == 160 || Main.npc[num140].type == 207 || Main.npc[num140].type == 209 || Main.npc[num140].type == 227 || Main.npc[num140].type == 228 || Main.npc[num140].type == 229 || Main.npc[num140].type == 358 || Main.npc[num140].type == 369 || Main.npc[num140].type == 550))
-+																	if (Main.npc[num140].active && (Main.npc[num140].type == 17 || Main.npc[num140].type == 19 || Main.npc[num140].type == 22 || Main.npc[num140].type == 38 || Main.npc[num140].type == 54 || Main.npc[num140].type == 107 || Main.npc[num140].type == 108 || Main.npc[num140].type == 142 || Main.npc[num140].type == 160 || Main.npc[num140].type == 207 || Main.npc[num140].type == 209 || Main.npc[num140].type == 227 || Main.npc[num140].type == 228 || Main.npc[num140].type == 229 || Main.npc[num140].type == 358 || Main.npc[num140].type == 369 || Main.npc[num140].type == 550 || (Main.npc[num140].townNPC && Main.npc[num140].modNPC?.AddToKingStatue == true)))
++																	if (Main.npc[num140].active && NPCLoader.CanGoToKingStatue(Main.npc[num140]))
  																	{
 -																		array[num139] = num140;
 +																		array.Add(num140);
@@ -135,7 +135,14 @@
  																	}
  																}
  																if (num139 > 0)
-@@ -2439,18 +_,14 @@
+@@ -2433,24 +_,21 @@
+ 																	int num141 = array[Main.rand.Next(num139)];
+ 																	Main.npc[num141].position.X = (float)(num133 - Main.npc[num141].width / 2);
+ 																	Main.npc[num141].position.Y = (float)(num134 - Main.npc[num141].height - 1);
++																	NPCLoader.OnGoToStatue(Main.npc[num141], true);
+ 																	NetMessage.SendData(23, -1, -1, null, num141, 0f, 0f, 0f, 0, 0, 0);
+ 																}
+ 															}
  														}
  														else if (num132 == 41 && Wiring.CheckMech(num131, num130, 300))
  														{
@@ -145,7 +152,7 @@
  															for (int num143 = 0; num143 < 200; num143++)
  															{
 -																if (Main.npc[num143].active && (Main.npc[num143].type == 18 || Main.npc[num143].type == 20 || Main.npc[num143].type == 124 || Main.npc[num143].type == 178 || Main.npc[num143].type == 208 || Main.npc[num143].type == 353))
-+																if (Main.npc[num143].active && (Main.npc[num143].type == 18 || Main.npc[num143].type == 20 || Main.npc[num143].type == 124 || Main.npc[num143].type == 178 || Main.npc[num143].type == 208 || Main.npc[num143].type == 353 || (Main.npc[num143].townNPC && Main.npc[num143].modNPC?.AddToQueenStatue == true)))
++																if (Main.npc[num143].active && NPCLoader.CanGoToQueenStatue(Main.npc[num143]))
  																{
 -																	array2[num142] = num143;
 +																	array2.Add(num143);
@@ -157,6 +164,14 @@
  																}
  															}
  															if (num142 > 0)
+@@ -2458,6 +_,7 @@
+ 																int num144 = array2[Main.rand.Next(num142)];
+ 																Main.npc[num144].position.X = (float)(num133 - Main.npc[num144].width / 2);
+ 																Main.npc[num144].position.Y = (float)(num134 - Main.npc[num144].height - 1);
++																NPCLoader.OnGoToStatue(Main.npc[num144], false);
+ 																NetMessage.SendData(23, -1, -1, null, num144, 0f, 0f, 0f, 0, 0, 0);
+ 															}
+ 														}
 @@ -2515,6 +_,7 @@
  						}
  					}

--- a/patches/tModLoader/Terraria/Wiring.cs.patch
+++ b/patches/tModLoader/Terraria/Wiring.cs.patch
@@ -113,7 +113,7 @@
  												{
  													WorldGen.SwitchMB(i, j);
  													return;
-@@ -2414,18 +_,14 @@
+@@ -2414,18 +_,15 @@
  														{
  															if (Wiring.CheckMech(num131, num130, 300))
  															{
@@ -123,7 +123,8 @@
  																for (int num140 = 0; num140 < 200; num140++)
  																{
 -																	if (Main.npc[num140].active && (Main.npc[num140].type == 17 || Main.npc[num140].type == 19 || Main.npc[num140].type == 22 || Main.npc[num140].type == 38 || Main.npc[num140].type == 54 || Main.npc[num140].type == 107 || Main.npc[num140].type == 108 || Main.npc[num140].type == 142 || Main.npc[num140].type == 160 || Main.npc[num140].type == 207 || Main.npc[num140].type == 209 || Main.npc[num140].type == 227 || Main.npc[num140].type == 228 || Main.npc[num140].type == 229 || Main.npc[num140].type == 358 || Main.npc[num140].type == 369 || Main.npc[num140].type == 550))
-+																	if (Main.npc[num140].active && NPCLoader.CanGoToKingStatue(Main.npc[num140]))
++																	bool vanillaCanGo = Main.npc[num140].type == 17 || Main.npc[num140].type == 19 || Main.npc[num140].type == 22 || Main.npc[num140].type == 38 || Main.npc[num140].type == 54 || Main.npc[num140].type == 107 || Main.npc[num140].type == 108 || Main.npc[num140].type == 142 || Main.npc[num140].type == 160 || Main.npc[num140].type == 207 || Main.npc[num140].type == 209 || Main.npc[num140].type == 227 || Main.npc[num140].type == 228 || Main.npc[num140].type == 229 || Main.npc[num140].type == 358 || Main.npc[num140].type == 369 || Main.npc[num140].type == 550;
++																	if (Main.npc[num140].active && NPCLoader.CanGoToStatue(Main.npc[num140], true, vanillaCanGo))
  																	{
 -																		array[num139] = num140;
 +																		array.Add(num140);
@@ -135,8 +136,7 @@
  																	}
  																}
  																if (num139 > 0)
-@@ -2433,24 +_,21 @@
- 																	int num141 = array[Main.rand.Next(num139)];
+@@ -2434,23 +_,21 @@
  																	Main.npc[num141].position.X = (float)(num133 - Main.npc[num141].width / 2);
  																	Main.npc[num141].position.Y = (float)(num134 - Main.npc[num141].height - 1);
  																	NetMessage.SendData(23, -1, -1, null, num141, 0f, 0f, 0f, 0, 0, 0);
@@ -152,7 +152,8 @@
  															for (int num143 = 0; num143 < 200; num143++)
  															{
 -																if (Main.npc[num143].active && (Main.npc[num143].type == 18 || Main.npc[num143].type == 20 || Main.npc[num143].type == 124 || Main.npc[num143].type == 178 || Main.npc[num143].type == 208 || Main.npc[num143].type == 353))
-+																if (Main.npc[num143].active && NPCLoader.CanGoToQueenStatue(Main.npc[num143]))
++																bool vanillaCanGo = Main.npc[num143].type == 18 || Main.npc[num143].type == 20 || Main.npc[num143].type == 124 || Main.npc[num143].type == 178 || Main.npc[num143].type == 208 || Main.npc[num143].type == 353;
++																if (Main.npc[num143].active && NPCLoader.CanGoToStatue(Main.npc[num143], false, vanillaCanGo))
  																{
 -																	array2[num142] = num143;
 +																	array2.Add(num143);
@@ -164,14 +165,14 @@
  																}
  															}
  															if (num142 > 0)
-@@ -2458,6 +_,7 @@
- 																int num144 = array2[Main.rand.Next(num142)];
+@@ -2459,6 +_,7 @@
  																Main.npc[num144].position.X = (float)(num133 - Main.npc[num144].width / 2);
  																Main.npc[num144].position.Y = (float)(num134 - Main.npc[num144].height - 1);
  																NetMessage.SendData(23, -1, -1, null, num144, 0f, 0f, 0f, 0, 0, 0);
 +																NPCLoader.OnGoToStatue(Main.npc[num144], false);
  															}
  														}
+ 													}
 @@ -2515,6 +_,7 @@
  						}
  					}

--- a/patches/tModLoader/Terraria/Wiring.cs.patch
+++ b/patches/tModLoader/Terraria/Wiring.cs.patch
@@ -113,6 +113,50 @@
  												{
  													WorldGen.SwitchMB(i, j);
  													return;
+@@ -2414,18 +_,14 @@
+ 														{
+ 															if (Wiring.CheckMech(num131, num130, 300))
+ 															{
+-																int[] array = new int[10];
++																List<int> array = new List<int>();
+ 																int num139 = 0;
+ 																for (int num140 = 0; num140 < 200; num140++)
+ 																{
+-																	if (Main.npc[num140].active && (Main.npc[num140].type == 17 || Main.npc[num140].type == 19 || Main.npc[num140].type == 22 || Main.npc[num140].type == 38 || Main.npc[num140].type == 54 || Main.npc[num140].type == 107 || Main.npc[num140].type == 108 || Main.npc[num140].type == 142 || Main.npc[num140].type == 160 || Main.npc[num140].type == 207 || Main.npc[num140].type == 209 || Main.npc[num140].type == 227 || Main.npc[num140].type == 228 || Main.npc[num140].type == 229 || Main.npc[num140].type == 358 || Main.npc[num140].type == 369 || Main.npc[num140].type == 550))
++																	if (Main.npc[num140].active && (Main.npc[num140].type == 17 || Main.npc[num140].type == 19 || Main.npc[num140].type == 22 || Main.npc[num140].type == 38 || Main.npc[num140].type == 54 || Main.npc[num140].type == 107 || Main.npc[num140].type == 108 || Main.npc[num140].type == 142 || Main.npc[num140].type == 160 || Main.npc[num140].type == 207 || Main.npc[num140].type == 209 || Main.npc[num140].type == 227 || Main.npc[num140].type == 228 || Main.npc[num140].type == 229 || Main.npc[num140].type == 358 || Main.npc[num140].type == 369 || Main.npc[num140].type == 550 || (Main.npc[num140].townNPC && Main.npc[num140].modNPC?.AddToKingStatue == true)))
+ 																	{
+-																		array[num139] = num140;
++																		array.Add(num140);
+ 																		num139++;
+-																		if (num139 >= 9)
+-																		{
+-																			break;
+-																		}
+ 																	}
+ 																}
+ 																if (num139 > 0)
+@@ -2439,18 +_,14 @@
+ 														}
+ 														else if (num132 == 41 && Wiring.CheckMech(num131, num130, 300))
+ 														{
+-															int[] array2 = new int[10];
++															List<int> array2 = new List<int>();
+ 															int num142 = 0;
+ 															for (int num143 = 0; num143 < 200; num143++)
+ 															{
+-																if (Main.npc[num143].active && (Main.npc[num143].type == 18 || Main.npc[num143].type == 20 || Main.npc[num143].type == 124 || Main.npc[num143].type == 178 || Main.npc[num143].type == 208 || Main.npc[num143].type == 353))
++																if (Main.npc[num143].active && (Main.npc[num143].type == 18 || Main.npc[num143].type == 20 || Main.npc[num143].type == 124 || Main.npc[num143].type == 178 || Main.npc[num143].type == 208 || Main.npc[num143].type == 353 || (Main.npc[num143].townNPC && Main.npc[num143].modNPC?.AddToQueenStatue == true)))
+ 																{
+-																	array2[num142] = num143;
++																	array2.Add(num143);
+ 																	num142++;
+-																	if (num142 >= 9)
+-																	{
+-																		break;
+-																	}
+ 																}
+ 															}
+ 															if (num142 > 0)
 @@ -2515,6 +_,7 @@
  						}
  					}

--- a/patches/tModLoader/Terraria/Wiring.cs.patch
+++ b/patches/tModLoader/Terraria/Wiring.cs.patch
@@ -139,8 +139,8 @@
  																	int num141 = array[Main.rand.Next(num139)];
  																	Main.npc[num141].position.X = (float)(num133 - Main.npc[num141].width / 2);
  																	Main.npc[num141].position.Y = (float)(num134 - Main.npc[num141].height - 1);
-+																	NPCLoader.OnGoToStatue(Main.npc[num141], true);
  																	NetMessage.SendData(23, -1, -1, null, num141, 0f, 0f, 0f, 0, 0, 0);
++																	NPCLoader.OnGoToStatue(Main.npc[num141], true);
  																}
  															}
  														}
@@ -168,8 +168,8 @@
  																int num144 = array2[Main.rand.Next(num142)];
  																Main.npc[num144].position.X = (float)(num133 - Main.npc[num144].width / 2);
  																Main.npc[num144].position.Y = (float)(num134 - Main.npc[num144].height - 1);
-+																NPCLoader.OnGoToStatue(Main.npc[num144], false);
  																NetMessage.SendData(23, -1, -1, null, num144, 0f, 0f, 0f, 0, 0, 0);
++																NPCLoader.OnGoToStatue(Main.npc[num144], false);
  															}
  														}
 @@ -2515,6 +_,7 @@


### PR DESCRIPTION
### Description of the Change
* Adds `GoToKingStatue` and `GoToQueenStatue` methods to `ModNPC` and `GlobalNPC`, which lets modders allow NPCs to be teleported to the King or Queen statues when triggered.
* Adds `OnGoToStatue` method to `ModNPC` and `GlobalNPC`, which allows adding effects when an NPC teleports to an statue.
* Also removes the limit to the amount of town NPCs each statue can support (used to be 10). Normally, if there are more than 10 of the NPCs a King/Queen statue can teleport, only the first 10, ordered by their slot in the NPCs array, can teleport to the statue.

### Sample Usage
Check `ExamplePerson` for a sample usage of this change.

