### PR TITLE
Fix vanilla angler quests reseting on world reload

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria.ModLoader.IO/WorldIO.cs
@@ -212,6 +212,10 @@ namespace Terraria.ModLoader.IO
 		}
 
 		internal static void LoadAnglerQuest(TagCompound tag) {
+			// Don't try to load modded angler quest item if there isn't one
+			if (!tag.ContainsKey("mod")) {
+				return;
+			}
 			var mod = ModLoader.GetMod(tag.GetString("mod"));
 			int type = mod?.ItemType(tag.GetString("itemName")) ?? 0;
 			if (type > 0) {


### PR DESCRIPTION
* Prevents the modded angler quest loading code from running if there was no modded angler quest saved on the previous session, which could only mean a vanilla quest was saved.
* The actual culprit was the call to `Main.AnglerQuestSwap()` at the end of the modded quest loading method, which should have only run when the item saved belonged to a mod that was not loaded or when the item was removed from said mod.
